### PR TITLE
#4 (Added) Add published status to posts and only show published posts on front page

### DIFF
--- a/api/db/migrations/20230613203114_add_draft_status_column/migration.sql
+++ b/api/db/migrations/20230613203114_add_draft_status_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "draft" BOOLEAN NOT NULL DEFAULT true;

--- a/api/db/migrations/20230613204131_rename_draft_to_published_column/migration.sql
+++ b/api/db/migrations/20230613204131_rename_draft_to_published_column/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `draft` on the `Post` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "draft",
+ADD COLUMN     "published" BOOLEAN NOT NULL DEFAULT false;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -30,4 +30,5 @@ model Post {
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])
   userId    Int
+  published Boolean  @default(false)
 }

--- a/api/src/graphql/adminPosts.sdl.ts
+++ b/api/src/graphql/adminPosts.sdl.ts
@@ -6,6 +6,7 @@ export const schema = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
     user: User!
+    published: Boolean!
   }
 
   type Query {
@@ -16,11 +17,13 @@ export const schema = gql`
   input CreatePostInput {
     title: String!
     body: String!
+    published: Boolean
   }
 
   input UpdatePostInput {
     title: String
     body: String
+    published: Boolean
   }
 
   type Mutation {

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -6,21 +6,12 @@ export const schema = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
     user: User!
+    published: Boolean!
   }
 
   type Query {
     posts: [Post!]! @skipAuth
     post(id: Int!): Post @skipAuth
-  }
-
-  input CreatePostInput {
-    title: String!
-    body: String!
-  }
-
-  input UpdatePostInput {
-    title: String
-    body: String
   }
 
   type Mutation {

--- a/api/src/services/adminPosts/adminPosts.ts
+++ b/api/src/services/adminPosts/adminPosts.ts
@@ -47,7 +47,7 @@ export const deletePost = async ({ id }) => {
   })
 }
 
-const verifyOwnership = async (id) => {
+const verifyOwnership = async ({ id }) => {
   if (await adminPost({ id })) {
     return true
   } else {

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -1,7 +1,7 @@
 import { db } from 'src/lib/db'
 
 export const posts = () => {
-  return db.post.findMany()
+  return db.post.findMany({ where: { published: true } })
 }
 
 export const post = ({ id }) => {

--- a/web/src/components/Post/EditPostCell/EditPostCell.tsx
+++ b/web/src/components/Post/EditPostCell/EditPostCell.tsx
@@ -14,6 +14,7 @@ export const QUERY = gql`
       title
       body
       createdAt
+      published
     }
   }
 `
@@ -24,6 +25,7 @@ const UPDATE_POST_MUTATION = gql`
       title
       body
       createdAt
+      published
     }
   }
 `

--- a/web/src/components/Post/Post/Post.tsx
+++ b/web/src/components/Post/Post/Post.tsx
@@ -1,10 +1,10 @@
+import type { DeletePostMutationVariables, FindPostById } from 'types/graphql'
+
 import { Link, routes, navigate } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { timeTag } from 'src/lib/formatters'
-
-import type { DeletePostMutationVariables, FindPostById } from 'types/graphql'
 
 const DELETE_POST_MUTATION = gql`
   mutation DeletePostMutation($id: Int!) {
@@ -56,6 +56,10 @@ const Post = ({ post }: Props) => {
             <tr>
               <th>Body</th>
               <td>{post.body}</td>
+            </tr>
+            <tr>
+              <th>Published</th>
+              <td>{post.published ? 'Yes' : 'No'}</td>
             </tr>
             <tr>
               <th>Created at</th>

--- a/web/src/components/Post/PostCell/PostCell.tsx
+++ b/web/src/components/Post/PostCell/PostCell.tsx
@@ -11,6 +11,7 @@ export const QUERY = gql`
       title
       body
       createdAt
+      published
     }
   }
 `

--- a/web/src/components/Post/PostForm/PostForm.tsx
+++ b/web/src/components/Post/PostForm/PostForm.tsx
@@ -1,3 +1,5 @@
+import type { EditPostById, UpdatePostInput } from 'types/graphql'
+
 import {
   Form,
   FormError,
@@ -5,9 +7,8 @@ import {
   Label,
   TextField,
   Submit,
+  CheckboxField,
 } from '@redwoodjs/forms'
-
-import type { EditPostById, UpdatePostInput } from 'types/graphql'
 import type { RWGqlError } from '@redwoodjs/forms'
 
 type FormPost = NonNullable<EditPostById['post']>
@@ -59,6 +60,20 @@ const PostForm = (props: PostFormProps) => {
         >
           Body
         </Label>
+
+        <Label
+          name="published"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Published
+        </Label>
+        <CheckboxField
+          name="published"
+          defaultChecked={props.post?.published}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
+        />
 
         <TextField
           name="body"

--- a/web/src/components/Post/Posts/Posts.tsx
+++ b/web/src/components/Post/Posts/Posts.tsx
@@ -1,11 +1,11 @@
+import type { DeletePostMutationVariables, FindPosts } from 'types/graphql'
+
 import { Link, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/Post/PostsCell'
 import { timeTag, truncate } from 'src/lib/formatters'
-
-import type { DeletePostMutationVariables, FindPosts } from 'types/graphql'
 
 const DELETE_POST_MUTATION = gql`
   mutation DeletePostMutation($id: Int!) {
@@ -44,6 +44,7 @@ const PostsList = ({ posts }: FindPosts) => {
             <th>Id</th>
             <th>Title</th>
             <th>Body</th>
+            <th>Published</th>
             <th>Created at</th>
             <th>&nbsp;</th>
           </tr>
@@ -54,6 +55,7 @@ const PostsList = ({ posts }: FindPosts) => {
               <td>{truncate(post.id)}</td>
               <td>{truncate(post.title)}</td>
               <td>{truncate(post.body)}</td>
+              <td>{post.published ? 'Yes' : 'No'}</td>
               <td>{timeTag(post.createdAt)}</td>
               <td>
                 <nav className="rw-table-actions">

--- a/web/src/components/Post/PostsCell/PostsCell.tsx
+++ b/web/src/components/Post/PostsCell/PostsCell.tsx
@@ -12,6 +12,7 @@ export const QUERY = gql`
       title
       body
       createdAt
+      published
     }
   }
 `


### PR DESCRIPTION
## 1. Summary

This PR aims to add the `published` property to all posts (`false` by default). The front page will only show posts that have been published and the dashboard has been updated to allow a logged in user to control the `published` status on a `post`.

Related to #4

## 2. Changed files

- migration.sql (Two files)
- schema.prisma
- adminPosts.sdl.ts
- posts.sdl.ts
- adminPosts.ts
- posts.ts
- EditPostCell.tsx
- Post.tsx
- PostCell.tsx
- PostForm.tsx
- Posts.tsx
- PostsCell.tsx

## 3. ChatGPT review of changes and advice for improvement

The changes seem well-intentioned and well-implemented. You've included the new 'published' property across all necessary files ensuring consistent behavior across the app. However, it's important to ensure proper testing to verify the functionality works as expected, especially since this update affects various parts of the system.

Remember to check:

- Default behavior when a new post is created (should it be a draft or published?)
- The behavior when switching a post from draft to published and vice versa.
- Accessibility of draft posts (Who can view them? Should they appear in public listings or only to the admin?)
- The UI reflecting the published status properly and consistently.

Keep up the good work!
