### PR TITLE
feat: Add roles as enum array

### DIFF
--- a/api/db/migrations/20230618064136_convert_roles_column_to_enum/migration.sql
+++ b/api/db/migrations/20230618064136_convert_roles_column_to_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `roles` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'MODERATOR', 'USER', 'GUEST');
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "roles",
+ADD COLUMN     "roles" "Role"[] DEFAULT ARRAY['GUEST']::"Role"[];

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -20,7 +20,7 @@ model User {
   resetToken          String?   // <─┤
   resetTokenExpiresAt DateTime? // <─┘
   posts               Post[]
-  roles               String @default("moderator")
+  roles               Role[]    @default([GUEST])
 }
 
 model Post {
@@ -31,4 +31,11 @@ model Post {
   user      User     @relation(fields: [userId], references: [id])
   userId    Int
   published Boolean  @default(false)
+}
+
+enum Role {
+  ADMIN
+  MODERATOR
+  USER
+  GUEST
 }

--- a/api/src/graphql/adminPosts.sdl.ts
+++ b/api/src/graphql/adminPosts.sdl.ts
@@ -10,8 +10,8 @@ export const schema = gql`
   }
 
   type Query {
-    adminPosts: [Post!]! @requireAuth(roles: ["admin"])
-    adminPost(id: Int!): Post @requireAuth(roles: ["admin"])
+    adminPosts: [Post!]! @requireAuth(roles: ["ADMIN"])
+    adminPost(id: Int!): Post @requireAuth(roles: ["ADMIN"])
   }
 
   input CreatePostInput {
@@ -27,9 +27,9 @@ export const schema = gql`
   }
 
   type Mutation {
-    createPost(input: CreatePostInput!): Post! @requireAuth(roles: ["admin"])
+    createPost(input: CreatePostInput!): Post! @requireAuth(roles: ["ADMIN"])
     updatePost(id: Int!, input: UpdatePostInput!): Post!
-      @requireAuth(roles: ["admin"])
-    deletePost(id: Int!): Post! @requireAuth(roles: ["admin"])
+      @requireAuth(roles: ["ADMIN"])
+    deletePost(id: Int!): Post! @requireAuth(roles: ["ADMIN"])
   }
 `


### PR DESCRIPTION
This PR converts the User's roles column from a String value with a default value of "moderator" to a column with an enums array as a data type. This is done so that we can support several types of users in the future. For example, users that can only read posts, users that can comment, and users that can write/edit posts.