### PR TITLE
Feat/add comment thumbs

### DIFF
--- a/api/db/migrations/20230624145731_add_comment_thumbs/migration.sql
+++ b/api/db/migrations/20230624145731_add_comment_thumbs/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Thumbs" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    "commentId" INTEGER NOT NULL,
+    "up" BOOLEAN NOT NULL,
+
+    CONSTRAINT "Thumbs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Thumbs" ADD CONSTRAINT "Thumbs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Thumbs" ADD CONSTRAINT "Thumbs_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "Comment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/migrations/20230624150656_rename_thumbs_to_singular_thumb/migration.sql
+++ b/api/db/migrations/20230624150656_rename_thumbs_to_singular_thumb/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Thumbs` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Thumbs" DROP CONSTRAINT "Thumbs_commentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Thumbs" DROP CONSTRAINT "Thumbs_userId_fkey";
+
+-- DropTable
+DROP TABLE "Thumbs";
+
+-- CreateTable
+CREATE TABLE "Thumb" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    "commentId" INTEGER NOT NULL,
+    "up" BOOLEAN NOT NULL,
+
+    CONSTRAINT "Thumb_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Thumb" ADD CONSTRAINT "Thumb_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Thumb" ADD CONSTRAINT "Thumb_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "Comment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "postgresql"
-  url = env("DATABASE_URL")
+  url      = env("DATABASE_URL")
 }
 
 generator client {
@@ -12,38 +12,39 @@ generator client {
 // to create migrations for them and apply to your dev DB.
 // TODO: Please remove the following example:
 model User {
-  id             Int @id @default(autoincrement())
-  email          String  @unique
+  id                  Int       @id @default(autoincrement())
+  email               String    @unique
   name                String?
-  hashedPassword      String    // <─┐
-  salt                String    // <─┼─ add these lines
-  resetToken          String?   // <─┤
+  hashedPassword      String // <─┐
+  salt                String // <─┼─ add these lines
+  resetToken          String? // <─┤
   resetTokenExpiresAt DateTime? // <─┘
   posts               Post[]
   roles               Role[]    @default([GUEST])
   profile             Profile?
   comments            Comment[]
+  thumbs              Thumbs[]
 }
 
 model Profile {
-  id        Int     @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   bio       String?
-  user      User    @relation(fields: [userId], references: [id])
-  userId    Int     @unique
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int      @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   avatar    String?
 }
 
 model Post {
-  id        Int      @id @default(autoincrement())
+  id        Int       @id @default(autoincrement())
   title     String
   body      String
-  createdAt DateTime @default(now())
-  user      User     @relation(fields: [userId], references: [id])
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id])
   userId    Int
-  published Boolean  @default(false)
-  type      PostType @default(ARTICLE)
+  published Boolean   @default(false)
+  type      PostType  @default(ARTICLE)
   comments  Comment[]
 }
 
@@ -63,14 +64,25 @@ enum PostType {
 }
 
 model Comment {
-  id        Int      @id @default(autoincrement())
+  id        Int       @id @default(autoincrement())
   body      String
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id])
+  userId    Int
+  post      Post      @relation(fields: [postId], references: [id])
+  postId    Int
+  parent    Comment?  @relation("ChildComments", fields: [parentId], references: [id])
+  parentId  Int?
+  children  Comment[] @relation("ChildComments")
+  thumbs    Thumbs[]
+}
+
+model Thumbs {
+  id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])
   userId    Int
-  post      Post     @relation(fields: [postId], references: [id])
-  postId    Int
-  parent    Comment? @relation("ChildComments", fields: [parentId], references: [id])
-  parentId  Int?
-  children  Comment[] @relation("ChildComments")
+  comment   Comment  @relation(fields: [commentId], references: [id])
+  commentId Int
+  up        Boolean
 }

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url = env("DATABASE_URL")
 }
 
 generator client {
@@ -12,39 +12,39 @@ generator client {
 // to create migrations for them and apply to your dev DB.
 // TODO: Please remove the following example:
 model User {
-  id                  Int       @id @default(autoincrement())
-  email               String    @unique
+  id             Int @id @default(autoincrement())
+  email          String  @unique
   name                String?
-  hashedPassword      String // <─┐
-  salt                String // <─┼─ add these lines
-  resetToken          String? // <─┤
+  hashedPassword      String    // <─┐
+  salt                String    // <─┼─ add these lines
+  resetToken          String?   // <─┤
   resetTokenExpiresAt DateTime? // <─┘
   posts               Post[]
   roles               Role[]    @default([GUEST])
   profile             Profile?
   comments            Comment[]
-  thumbs              Thumbs[]
+  thumbs              Thumb[]
 }
 
 model Profile {
-  id        Int      @id @default(autoincrement())
+  id        Int     @id @default(autoincrement())
   bio       String?
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int      @unique
+  user      User    @relation(fields: [userId], references: [id])
+  userId    Int     @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   avatar    String?
 }
 
 model Post {
-  id        Int       @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   title     String
   body      String
-  createdAt DateTime  @default(now())
-  user      User      @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
   userId    Int
-  published Boolean   @default(false)
-  type      PostType  @default(ARTICLE)
+  published Boolean  @default(false)
+  type      PostType @default(ARTICLE)
   comments  Comment[]
 }
 
@@ -64,20 +64,20 @@ enum PostType {
 }
 
 model Comment {
-  id        Int       @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   body      String
-  createdAt DateTime  @default(now())
-  user      User      @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
   userId    Int
-  post      Post      @relation(fields: [postId], references: [id])
+  post      Post     @relation(fields: [postId], references: [id])
   postId    Int
-  parent    Comment?  @relation("ChildComments", fields: [parentId], references: [id])
+  parent    Comment? @relation("ChildComments", fields: [parentId], references: [id])
   parentId  Int?
   children  Comment[] @relation("ChildComments")
-  thumbs    Thumbs[]
+  thumbs    Thumb[]
 }
 
-model Thumbs {
+model Thumb {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])

--- a/api/src/graphql/comments.sdl.ts
+++ b/api/src/graphql/comments.sdl.ts
@@ -10,6 +10,7 @@ export const schema = gql`
     parent: Comment
     parentId: Int
     children: [Comment]!
+    thumbs: [Thumb]!
   }
 
   type Query {

--- a/api/src/graphql/thumbs.sdl.ts
+++ b/api/src/graphql/thumbs.sdl.ts
@@ -20,6 +20,11 @@ export const schema = gql`
     up: Boolean!
   }
 
+  input CreateUpdateOrDeleteThumbInput {
+    commentId: Int!
+    up: Boolean!
+  }
+
   input UpdateThumbInput {
     userId: Int
     commentId: Int
@@ -28,6 +33,8 @@ export const schema = gql`
 
   type Mutation {
     createThumb(input: CreateThumbInput!): Thumb! @requireAuth
+    createUpdateOrDeleteThumb(input: CreateUpdateOrDeleteThumbInput!): Thumb!
+      @requireAuth
     updateThumb(id: Int!, input: UpdateThumbInput!): Thumb! @requireAuth
     deleteThumb(id: Int!): Thumb! @requireAuth
   }

--- a/api/src/graphql/thumbs.sdl.ts
+++ b/api/src/graphql/thumbs.sdl.ts
@@ -1,0 +1,34 @@
+export const schema = gql`
+  type Thumb {
+    id: Int!
+    createdAt: DateTime!
+    user: User!
+    userId: Int!
+    comment: Comment!
+    commentId: Int!
+    up: Boolean!
+  }
+
+  type Query {
+    thumbs: [Thumb!]! @requireAuth
+    thumb(id: Int!): Thumb @requireAuth
+  }
+
+  input CreateThumbInput {
+    userId: Int!
+    commentId: Int!
+    up: Boolean!
+  }
+
+  input UpdateThumbInput {
+    userId: Int
+    commentId: Int
+    up: Boolean
+  }
+
+  type Mutation {
+    createThumb(input: CreateThumbInput!): Thumb! @requireAuth
+    updateThumb(id: Int!, input: UpdateThumbInput!): Thumb! @requireAuth
+    deleteThumb(id: Int!): Thumb! @requireAuth
+  }
+`

--- a/api/src/services/comments/comments.ts
+++ b/api/src/services/comments/comments.ts
@@ -75,4 +75,7 @@ export const Comment: CommentRelationResolvers = {
   children: (_obj, { root }) => {
     return db.comment.findUnique({ where: { id: root?.id } }).children()
   },
+  thumbs: (_obj, { root }) => {
+    return db.comment.findUnique({ where: { id: root?.id } }).thumbs()
+  },
 }

--- a/api/src/services/comments/comments.ts
+++ b/api/src/services/comments/comments.ts
@@ -19,8 +19,6 @@ export const comment: QueryResolvers['comment'] = ({ id }) => {
 export const createComment: MutationResolvers['createComment'] = async ({
   input,
 }) => {
-  console.log('createComment input: ', input)
-
   if (!input.postId) {
     throw new Error('Post ID is required for Comment')
   }

--- a/api/src/services/thumbs/thumbs.scenarios.ts
+++ b/api/src/services/thumbs/thumbs.scenarios.ts
@@ -1,0 +1,83 @@
+import type { Prisma, Thumb } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.ThumbCreateArgs>({
+  thumb: {
+    one: {
+      data: {
+        up: true,
+        user: {
+          create: {
+            email: 'String4796571',
+            hashedPassword: 'String',
+            salt: 'String',
+          },
+        },
+        comment: {
+          create: {
+            body: 'String',
+            user: {
+              create: {
+                email: 'String4623626',
+                hashedPassword: 'String',
+                salt: 'String',
+              },
+            },
+            post: {
+              create: {
+                title: 'String',
+                body: 'String',
+                user: {
+                  create: {
+                    email: 'String2063275',
+                    hashedPassword: 'String',
+                    salt: 'String',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    two: {
+      data: {
+        up: true,
+        user: {
+          create: {
+            email: 'String4313646',
+            hashedPassword: 'String',
+            salt: 'String',
+          },
+        },
+        comment: {
+          create: {
+            body: 'String',
+            user: {
+              create: {
+                email: 'String3793891',
+                hashedPassword: 'String',
+                salt: 'String',
+              },
+            },
+            post: {
+              create: {
+                title: 'String',
+                body: 'String',
+                user: {
+                  create: {
+                    email: 'String6461807',
+                    hashedPassword: 'String',
+                    salt: 'String',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<Thumb, 'thumb'>

--- a/api/src/services/thumbs/thumbs.test.ts
+++ b/api/src/services/thumbs/thumbs.test.ts
@@ -1,0 +1,55 @@
+import type { Thumb } from '@prisma/client'
+
+import { thumbs, thumb, createThumb, updateThumb, deleteThumb } from './thumbs'
+import type { StandardScenario } from './thumbs.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('thumbs', () => {
+  scenario('returns all thumbs', async (scenario: StandardScenario) => {
+    const result = await thumbs()
+
+    expect(result.length).toEqual(Object.keys(scenario.thumb).length)
+  })
+
+  scenario('returns a single thumb', async (scenario: StandardScenario) => {
+    const result = await thumb({ id: scenario.thumb.one.id })
+
+    expect(result).toEqual(scenario.thumb.one)
+  })
+
+  scenario('creates a thumb', async (scenario: StandardScenario) => {
+    const result = await createThumb({
+      input: {
+        userId: scenario.thumb.two.userId,
+        commentId: scenario.thumb.two.commentId,
+        up: true,
+      },
+    })
+
+    expect(result.userId).toEqual(scenario.thumb.two.userId)
+    expect(result.commentId).toEqual(scenario.thumb.two.commentId)
+    expect(result.up).toEqual(true)
+  })
+
+  scenario('updates a thumb', async (scenario: StandardScenario) => {
+    const original = (await thumb({ id: scenario.thumb.one.id })) as Thumb
+    const result = await updateThumb({
+      id: original.id,
+      input: { up: false },
+    })
+
+    expect(result.up).toEqual(false)
+  })
+
+  scenario('deletes a thumb', async (scenario: StandardScenario) => {
+    const original = (await deleteThumb({ id: scenario.thumb.one.id })) as Thumb
+    const result = await thumb({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/thumbs/thumbs.ts
+++ b/api/src/services/thumbs/thumbs.ts
@@ -1,0 +1,88 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ThumbRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const thumbs: QueryResolvers['thumbs'] = () => {
+  return db.thumb.findMany()
+}
+
+export const thumbsByCommentId: QueryResolvers['thumbsByCommentId'] = ({
+  commentId,
+}) => {
+  return db.thumb.findMany({
+    where: { commentId },
+  })
+}
+
+export const thumb: QueryResolvers['thumb'] = ({ id }) => {
+  return db.thumb.findUnique({
+    where: { id },
+  })
+}
+
+export const createUpdateOrDeleteThumb: MutationResolvers['createUpdateOrDeleteThumb'] =
+  async ({ input }) => {
+    const { up } = input
+
+    // check if user has already thumbed this comment
+    const userId = context.currentUser.id
+
+    const thumb = await db.thumb.findFirst({
+      where: { userId, commentId: input.commentId },
+    })
+
+    // if not exists, create a new thumb
+    if (!thumb) {
+      return db.thumb.create({
+        data: { ...input, userId },
+      })
+    }
+
+    // if not same, update the thumb
+    if (thumb.up !== up) {
+      return db.thumb.update({
+        data: { ...input, userId },
+        where: { id: thumb.id },
+      })
+    }
+    // if exists, check if the thumb is the same
+    // if same, delete the thumb
+    return db.thumb.delete({
+      where: { id: thumb.id },
+    })
+  }
+
+export const createThumb: MutationResolvers['createThumb'] = ({ input }) => {
+  return db.thumb.create({
+    data: input,
+  })
+}
+
+export const updateThumb: MutationResolvers['updateThumb'] = ({
+  id,
+  input,
+}) => {
+  return db.thumb.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deleteThumb: MutationResolvers['deleteThumb'] = ({ id }) => {
+  return db.thumb.delete({
+    where: { id },
+  })
+}
+
+export const Thumb: ThumbRelationResolvers = {
+  user: (_obj, { root }) => {
+    return db.thumb.findUnique({ where: { id: root?.id } }).user()
+  },
+  comment: (_obj, { root }) => {
+    return db.thumb.findUnique({ where: { id: root?.id } }).comment()
+  },
+}

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -32,4 +32,7 @@ export const User: UserRelationResolvers = {
   profile: (_obj, { root }) => {
     return db.user.findUnique({ where: { id: root?.id } }).profile()
   },
+  thumbs: (_obj, { root }) => {
+    return db.user.findMany({ where: { id: root?.id } }).thumbs()
+  },
 }

--- a/web/src/components/Article/Article.tsx
+++ b/web/src/components/Article/Article.tsx
@@ -8,6 +8,8 @@ import ArticleTypeIcon, { EPostType } from '../ArticleTypeIcon/ArticleTypeIcon'
 import Comment from '../Comment/Comment'
 import CommentForm from '../CommentForm/CommentForm'
 
+import { hotScore } from './helpers/sort-comments'
+
 interface Props {
   article: Post
 }
@@ -22,27 +24,20 @@ const Article = ({ article }: Props) => {
   })
 
   const sortedComments = useMemo(() => {
-    // first sort by thumbs up
-    // then sort by thumbs down
-    // then sort by date
+    return [...article.comments].sort((a, b) => {
+      const aUpVotes = a.thumbs.filter((t) => t.up).length
+      const aDownVotes = a.thumbs.filter((t) => !t.up).length
 
-    return [...article.comments]
-      .sort((a, b) => {
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      })
+      const bUpVotes = b.thumbs.filter((t) => t.up).length
+      const bDownVotes = b.thumbs.filter((t) => !t.up).length
 
-      .sort((a, b) => {
-        return (
-          a.thumbs.filter((t) => !t.up).length -
-          b.thumbs.filter((t) => !t.up).length
-        )
-      })
-      .sort((a, b) => {
-        return (
-          b.thumbs.filter((t) => t.up).length -
-          a.thumbs.filter((t) => t.up).length
-        )
-      })
+      const scoreA = hotScore(aUpVotes, aDownVotes, new Date(a.createdAt))
+      const scoreB = hotScore(bUpVotes, bDownVotes, new Date(b.createdAt))
+
+      if (scoreA > scoreB) return -1
+      if (scoreA < scoreB) return 1
+      return 0
+    })
   }, [article.comments])
 
   return (

--- a/web/src/components/Article/Article.tsx
+++ b/web/src/components/Article/Article.tsx
@@ -22,12 +22,27 @@ const Article = ({ article }: Props) => {
   })
 
   const sortedComments = useMemo(() => {
-    return [...article.comments].sort((a, b) => {
-      return (
-        b.thumbs.filter((t) => t.up).length -
-        a.thumbs.filter((t) => t.up).length
-      )
-    })
+    // first sort by thumbs up
+    // then sort by thumbs down
+    // then sort by date
+
+    return [...article.comments]
+      .sort((a, b) => {
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      })
+
+      .sort((a, b) => {
+        return (
+          a.thumbs.filter((t) => !t.up).length -
+          b.thumbs.filter((t) => !t.up).length
+        )
+      })
+      .sort((a, b) => {
+        return (
+          b.thumbs.filter((t) => t.up).length -
+          a.thumbs.filter((t) => t.up).length
+        )
+      })
   }, [article.comments])
 
   return (

--- a/web/src/components/Article/Article.tsx
+++ b/web/src/components/Article/Article.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import type { Post } from 'types/graphql'
 
 import { Link, routes } from '@redwoodjs/router'
@@ -18,6 +20,15 @@ const Article = ({ article }: Props) => {
     hour: '2-digit',
     minute: '2-digit',
   })
+
+  const sortedComments = useMemo(() => {
+    return [...article.comments].sort((a, b) => {
+      return (
+        b.thumbs.filter((t) => t.up).length -
+        a.thumbs.filter((t) => t.up).length
+      )
+    })
+  }, [article.comments])
 
   return (
     <article className="mb-4 p-2">
@@ -42,7 +53,7 @@ const Article = ({ article }: Props) => {
       <div>{article.body}</div>
       <h3 className="mt-4 text-lg font-light text-gray-600">Comments</h3>
       <ul className="mt-4 max-w-xl">
-        {article.comments.map((comment) => (
+        {sortedComments.map((comment) => (
           <li key={comment.id} className="mb-4">
             <Comment comment={comment} />
           </li>

--- a/web/src/components/Article/helpers/sort-comments.tsx
+++ b/web/src/components/Article/helpers/sort-comments.tsx
@@ -1,0 +1,20 @@
+function epochSeconds(date: Date): number {
+  const epoch = new Date(Date.UTC(1970, 0, 1))
+  const diff = date.getTime() - epoch.getTime()
+
+  return Math.floor(diff / 1000)
+}
+
+export function hotScore(
+  upvotes: number,
+  downvotes: number,
+  createdAt: Date,
+  upvoteWeight = 1,
+  downvoteWeight = 0.5,
+  timeWeight = 0.00001
+): number {
+  const s = upvoteWeight * upvotes - downvoteWeight * downvotes
+  const seconds = epochSeconds(createdAt) - 1134028003
+  const timeScore = seconds * timeWeight
+  return s + timeScore
+}

--- a/web/src/components/ArticleCell/ArticleCell.tsx
+++ b/web/src/components/ArticleCell/ArticleCell.tsx
@@ -26,6 +26,11 @@ export const QUERY = gql`
             avatar
           }
         }
+        thumbs {
+          id
+          userId
+          up
+        }
       }
     }
   }
@@ -54,5 +59,6 @@ export const Failure = ({
 export const Success = ({
   article,
 }: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
+  console.log(article)
   return <Article article={article} />
 }

--- a/web/src/components/ArticleCell/ArticleCell.tsx
+++ b/web/src/components/ArticleCell/ArticleCell.tsx
@@ -19,6 +19,7 @@ export const QUERY = gql`
         id
         body
         createdAt
+        postId
         user {
           name
           email

--- a/web/src/components/ArticleCell/ArticleCell.tsx
+++ b/web/src/components/ArticleCell/ArticleCell.tsx
@@ -59,6 +59,5 @@ export const Failure = ({
 export const Success = ({
   article,
 }: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
-  console.log(article)
   return <Article article={article} />
 }

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -22,11 +22,15 @@ const CREATE_UPDATE_OR_DELETE_THUMB = gql`
 `
 
 export default ({ comment }: ICommentProps) => {
-  const [createUpdateOrDeleteThumb, { loading, error }] = useMutation(
+  const [createUpdateOrDeleteThumb] = useMutation(
     CREATE_UPDATE_OR_DELETE_THUMB,
     {
-      onCompleted: () => {
-        toast.success('You voted this comment!')
+      onCompleted: (data) => {
+        toast.success(
+          `You voted this comment ${
+            data.createUpdateOrDeleteThumb.up ? 'up' : 'down'
+          }`
+        )
       },
     }
   )

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -1,5 +1,8 @@
 import type { Comment } from 'types/graphql'
 
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+
 import Avatar from '../Avatar/Avatar'
 import Thumbs from '../Thumbs/Thumbs'
 
@@ -7,7 +10,33 @@ interface ICommentProps {
   comment: Comment
 }
 
+const CREATE_UPDATE_OR_DELETE_THUMB = gql`
+  mutation CreateUpdateOrDeleteMutation(
+    $input: CreateUpdateOrDeleteThumbInput!
+  ) {
+    createUpdateOrDeleteThumb(input: $input) {
+      commentId
+      up
+    }
+  }
+`
+
 export default ({ comment }: ICommentProps) => {
+  const [createUpdateOrDeleteThumb, { loading, error }] = useMutation(
+    CREATE_UPDATE_OR_DELETE_THUMB,
+    {
+      onCompleted: () => {
+        toast.success('You voted this comment!')
+      },
+    }
+  )
+
+  const handleThumbClick = (up: boolean) => {
+    createUpdateOrDeleteThumb({
+      variables: { input: { commentId: comment.id, up } },
+    })
+  }
+
   return (
     <div className="rounded-lg bg-slate-100 p-4 ">
       <div className="flex flex-row items-center gap-4">
@@ -34,7 +63,11 @@ export default ({ comment }: ICommentProps) => {
           </span>
         </div>
         <div className="ml-auto">
-          <Thumbs thumbs={comment.thumbs} />
+          <Thumbs
+            thumbs={comment.thumbs}
+            entityId={comment.id}
+            onThumb={handleThumbClick}
+          />
         </div>
       </div>
       <div className="ml-14 mt-4 text-sm leading-relaxed text-slate-600">

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -26,8 +26,6 @@ const CREATE_UPDATE_OR_DELETE_THUMB = gql`
 `
 
 export default ({ comment }: ICommentProps) => {
-  console.log(comment)
-
   const [createUpdateOrDeleteThumb] = useMutation(
     CREATE_UPDATE_OR_DELETE_THUMB,
     {

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import type { Comment } from 'types/graphql'
 
 import { useMutation } from '@redwoodjs/web'
@@ -45,6 +47,33 @@ export default ({ comment }: ICommentProps) => {
     }
   )
 
+  const rating = useMemo(() => {
+    if (comment.thumbs.filter((t) => !t.up).length === 0) {
+      return 1
+    }
+
+    const rating =
+      comment.thumbs.filter((t) => t.up).length -
+        comment.thumbs.filter((t) => !t.up).length >
+      0
+        ? 0
+        : -1
+
+    return rating
+  }, [comment.thumbs])
+
+  const ratingOpacity = useMemo(() => {
+    if (rating === 0) {
+      return 'opacity-90'
+    }
+
+    if (rating < 0) {
+      return 'opacity-75'
+    }
+
+    return ''
+  }, [rating])
+
   const handleThumbClick = (up: boolean) => {
     createUpdateOrDeleteThumb({
       variables: { input: { commentId: comment.id, up } },
@@ -52,7 +81,9 @@ export default ({ comment }: ICommentProps) => {
   }
 
   return (
-    <div className="rounded-lg bg-slate-100 p-4 ">
+    <div
+      className={`rounded-lg bg-slate-100 p-4 transition-opacity ${ratingOpacity}`}
+    >
       <div className="flex flex-row items-center gap-4">
         <Avatar
           src={comment.user?.profile?.avatar}

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -3,6 +3,8 @@ import type { Comment } from 'types/graphql'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
+import { QUERY as FindArticleQuery } from 'src/components/ArticleCell'
+
 import Avatar from '../Avatar/Avatar'
 import Thumbs from '../Thumbs/Thumbs'
 
@@ -22,6 +24,8 @@ const CREATE_UPDATE_OR_DELETE_THUMB = gql`
 `
 
 export default ({ comment }: ICommentProps) => {
+  console.log(comment)
+
   const [createUpdateOrDeleteThumb] = useMutation(
     CREATE_UPDATE_OR_DELETE_THUMB,
     {
@@ -32,6 +36,12 @@ export default ({ comment }: ICommentProps) => {
           }`
         )
       },
+      refetchQueries: [
+        {
+          query: FindArticleQuery,
+          variables: { id: comment.postId, $id: comment.postId },
+        },
+      ],
     }
   )
 

--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -1,6 +1,7 @@
 import type { Comment } from 'types/graphql'
 
 import Avatar from '../Avatar/Avatar'
+import Thumbs from '../Thumbs/Thumbs'
 
 interface ICommentProps {
   comment: Comment
@@ -31,6 +32,9 @@ export default ({ comment }: ICommentProps) => {
               minute: '2-digit',
             })}
           </span>
+        </div>
+        <div className="ml-auto">
+          <Thumbs thumbs={comment.thumbs} />
         </div>
       </div>
       <div className="ml-14 mt-4 text-sm leading-relaxed text-slate-600">

--- a/web/src/components/EditAccountForm/EditAccountForm.tsx
+++ b/web/src/components/EditAccountForm/EditAccountForm.tsx
@@ -27,8 +27,6 @@ const EditAccountForm = (props: EditAccountFormProps) => {
     props.onSave(data)
   }
 
-  console.log({ props })
-
   return (
     <div className="rw-form-wrapper">
       <Form<FormAccount> onSubmit={onSubmit} error={props.error}>

--- a/web/src/components/Thumb/Thumb.stories.tsx
+++ b/web/src/components/Thumb/Thumb.stories.tsx
@@ -1,0 +1,25 @@
+// When you've added props to your component,
+// pass Storybook's `args` through this story to control it from the addons panel:
+//
+// ```tsx
+// import type { ComponentStory } from '@storybook/react'
+//
+// export const generated: ComponentStory<typeof Thumb> = (args) => {
+//   return <Thumb {...args} />
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { ComponentMeta } from '@storybook/react'
+
+import Thumb from './Thumb'
+
+export const generated = () => {
+  return <Thumb />
+}
+
+export default {
+  title: 'Components/Thumb',
+  component: Thumb,
+} as ComponentMeta<typeof Thumb>

--- a/web/src/components/Thumb/Thumb.test.tsx
+++ b/web/src/components/Thumb/Thumb.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import Thumb from './Thumb'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('Thumb', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<Thumb />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -9,7 +9,7 @@ interface IThumbProps {
 
 const Thumb = ({ up, active, count, onClick }: IThumbProps) => {
   return (
-    <Button className={active ? 'border-2 border-black' : ''} onClick={onClick}>
+    <Button onClick={onClick} variant={active ? 'filled' : 'outlined'}>
       {up ? '👍' : '👎'} {count}
     </Button>
   )

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -4,12 +4,13 @@ interface IThumbProps {
   up: boolean
   active?: boolean
   count: number
+  onClick: () => void
 }
 
-const Thumb = ({ up, active, count }: IThumbProps) => {
+const Thumb = ({ up, active, count, onClick }: IThumbProps) => {
   return (
-    <Button className={active ? 'border-2 border-black' : ''}>
-      {up ? 'Up' : 'Down'} {count}
+    <Button className={active ? 'border-2 border-black' : ''} onClick={onClick}>
+      {up ? '👍' : '👎'} {count}
     </Button>
   )
 }

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -1,0 +1,17 @@
+import Button from '../Button/Button'
+
+interface IThumbProps {
+  up: boolean
+  active?: boolean
+  count: number
+}
+
+const Thumb = ({ up, active, count }: IThumbProps) => {
+  return (
+    <Button className={active ? 'border-2 border-black' : ''}>
+      {up ? 'Up' : 'Down'} {count}
+    </Button>
+  )
+}
+
+export default Thumb

--- a/web/src/components/Thumbs/Thumbs.stories.tsx
+++ b/web/src/components/Thumbs/Thumbs.stories.tsx
@@ -1,0 +1,25 @@
+// When you've added props to your component,
+// pass Storybook's `args` through this story to control it from the addons panel:
+//
+// ```tsx
+// import type { ComponentStory } from '@storybook/react'
+//
+// export const generated: ComponentStory<typeof Thumbs> = (args) => {
+//   return <Thumbs {...args} />
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { ComponentMeta } from '@storybook/react'
+
+import Thumbs from './Thumbs'
+
+export const generated = () => {
+  return <Thumbs />
+}
+
+export default {
+  title: 'Components/Thumbs',
+  component: Thumbs,
+} as ComponentMeta<typeof Thumbs>

--- a/web/src/components/Thumbs/Thumbs.test.tsx
+++ b/web/src/components/Thumbs/Thumbs.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import Thumbs from './Thumbs'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('Thumbs', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<Thumbs />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Thumbs/Thumbs.tsx
+++ b/web/src/components/Thumbs/Thumbs.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from 'react'
+
+import { useAuth } from 'src/auth'
+
+import Thumb from '../Thumb/Thumb'
+
+export interface IThumbProps {
+  thumbs: Thumbs[]
+}
+
+const Thumbs = (props: IThumbProps) => {
+  const { currentUser } = useAuth()
+
+  // useMemo to filter up and down thumbs
+  const upThumbs = useMemo(() => {
+    return props.thumbs.filter((thumb) => thumb.up)
+  }, [props.thumbs])
+
+  const downThumbs = useMemo(() => {
+    return props.thumbs.filter((thumb) => !thumb.up)
+  }, [props.thumbs])
+
+  const upCount = useMemo(() => {
+    return upThumbs.length
+  }, [upThumbs])
+
+  const downCount = useMemo(() => {
+    return downThumbs.length
+  }, [downThumbs])
+
+  const currentUserThumb = useMemo(() => {
+    return props.thumbs.find((thumb) => thumb.user.id === currentUser.id)
+  }, [props.thumbs, currentUser])
+
+  return (
+    <div className="flex gap-2">
+      <Thumb up={true} count={upCount} active={currentUserThumb?.up} />
+      <Thumb
+        up={false}
+        count={downCount}
+        active={currentUserThumb?.up === false}
+      />
+    </div>
+  )
+}
+
+export default Thumbs

--- a/web/src/components/Thumbs/Thumbs.tsx
+++ b/web/src/components/Thumbs/Thumbs.tsx
@@ -6,6 +6,8 @@ import Thumb from '../Thumb/Thumb'
 
 export interface IThumbProps {
   thumbs: Thumbs[]
+  entityId: number
+  onThumb: (up: boolean) => void
 }
 
 const Thumbs = (props: IThumbProps) => {
@@ -29,16 +31,22 @@ const Thumbs = (props: IThumbProps) => {
   }, [downThumbs])
 
   const currentUserThumb = useMemo(() => {
-    return props.thumbs.find((thumb) => thumb.user.id === currentUser.id)
+    return props.thumbs.find((thumb) => thumb.userId === currentUser.id)
   }, [props.thumbs, currentUser])
 
   return (
     <div className="flex gap-2">
-      <Thumb up={true} count={upCount} active={currentUserThumb?.up} />
+      <Thumb
+        up={true}
+        count={upCount}
+        active={currentUserThumb?.up}
+        onClick={() => props.onThumb(true)}
+      />
       <Thumb
         up={false}
         count={downCount}
         active={currentUserThumb?.up === false}
+        onClick={() => props.onThumb(false)}
       />
     </div>
   )


### PR DESCRIPTION
This PR adds... Comment up/down voting aka thumbs!!!
- Every comment has two thumbs up / down buttons on the top right
- Clicking one of the thumbs will 
  - Create, update or remove the thumb in the database
  - Re-fetch the article with the comments with the thumbs
  - Show a toastie
- Based on the up/down vote ration, the opacity of the comment will also be affected. E.g. downvoted comments will be a bit transparent.
- Comments will now also be sorted. First by date, then by down votes, then by up votes.

Resolves #30 