### PR TITLE
Feat/34 show reisgenootschap from data

### DIFF
--- a/api/db/migrations/20230627111425_add_name_and_japanese_name_properties_to_profile_model/migration.sql
+++ b/api/db/migrations/20230627111425_add_name_and_japanese_name_properties_to_profile_model/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN     "japaneseName" TEXT,
+ADD COLUMN     "name" TEXT;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -27,13 +27,15 @@ model User {
 }
 
 model Profile {
-  id        Int     @id @default(autoincrement())
-  bio       String?
-  user      User    @relation(fields: [userId], references: [id])
-  userId    Int     @unique
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  avatar    String?
+  id            Int     @id @default(autoincrement())
+  bio           String?
+  user          User    @relation(fields: [userId], references: [id])
+  userId        Int     @unique
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  avatar        String?
+  name          String?
+  japaneseName  String?
 }
 
 model Post {

--- a/api/src/graphql/profiles.sdl.ts
+++ b/api/src/graphql/profiles.sdl.ts
@@ -7,6 +7,8 @@ export const schema = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
     avatar: String
+    name: String
+    japaneseName: String
   }
 
   type Query {
@@ -18,11 +20,15 @@ export const schema = gql`
   input CreateProfileInput {
     bio: String
     avatar: String
+    name: String
+    japaneseName: String
   }
 
   input UpdateProfileInput {
     bio: String
     avatar: String
+    name: String
+    japaneseName: String
   }
 
   type Mutation {

--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -14,6 +14,7 @@ export const schema = gql`
   type Query {
     users: [User!]! @requireAuth
     user(id: Int!): User @requireAuth
+    usersWithRoles(roles: [Role!]!): [User!]! @requireAuth
   }
 
   input CreateUserInput {
@@ -40,5 +41,12 @@ export const schema = gql`
 
   type Mutation {
     updateUserProfile(input: UpdateUserProfileInput!): User! @requireAuth
+  }
+
+  enum Role {
+    ADMIN
+    MODERATOR
+    USER
+    GUEST
   }
 `

--- a/api/src/services/profiles/profiles.ts
+++ b/api/src/services/profiles/profiles.ts
@@ -4,8 +4,6 @@ import type {
   ProfileRelationResolvers,
 } from 'types/graphql'
 
-import { ForbiddenError } from '@redwoodjs/graphql-server'
-
 import { db } from 'src/lib/db'
 
 export const profiles: QueryResolvers['profiles'] = () => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -1,9 +1,19 @@
-import type { QueryResolvers, UserRelationResolvers } from 'types/graphql'
+import type { QueryResolvers, Role, UserRelationResolvers } from 'types/graphql'
 
 import { db } from 'src/lib/db'
 
 export const users: QueryResolvers['users'] = () => {
   return db.user.findMany()
+}
+
+export const usersWithRoles: QueryResolvers['usersWithRoles'] = ({ roles }) => {
+  return db.user.findMany({
+    where: {
+      roles: {
+        hasSome: roles as Role[],
+      },
+    },
+  })
 }
 
 export const user: QueryResolvers['user'] = ({ id }) => {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -13,6 +13,9 @@ export const usersWithRoles: QueryResolvers['usersWithRoles'] = ({ roles }) => {
         hasSome: roles as Role[],
       },
     },
+    orderBy: {
+      name: 'asc',
+    },
   })
 }
 

--- a/web/src/components/EditAccountForm/EditAccountForm.tsx
+++ b/web/src/components/EditAccountForm/EditAccountForm.tsx
@@ -42,13 +42,15 @@ const EditAccountForm = (props: EditAccountFormProps) => {
           className="rw-label"
           errorClassName="rw-label rw-label-error"
         >
-          Name
+          Name (deprecated, now in profile)
         </Label>
 
         <TextField
           name="name"
+          disabled
           defaultValue={props.user?.name}
-          className="rw-input"
+          className="rw-input cursor-not-allowed"
+          title="Deprecated. Name is now in profile"
           errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />

--- a/web/src/components/Profile/EditProfileCell/EditProfileCell.tsx
+++ b/web/src/components/Profile/EditProfileCell/EditProfileCell.tsx
@@ -18,6 +18,8 @@ export const QUERY = gql`
       createdAt
       updatedAt
       avatar
+      name
+      japaneseName
     }
   }
 `
@@ -29,6 +31,8 @@ const UPDATE_PROFILE_MUTATION = gql`
       createdAt
       updatedAt
       avatar
+      name
+      japaneseName
     }
   }
 `

--- a/web/src/components/Profile/Profile/Profile.tsx
+++ b/web/src/components/Profile/Profile/Profile.tsx
@@ -1,22 +1,9 @@
-import type {
-  DeleteProfileMutationVariables,
-  FindProfileById,
-} from 'types/graphql'
+import type { FindProfileById } from 'types/graphql'
 
-import { Link, routes, navigate } from '@redwoodjs/router'
-import { useMutation } from '@redwoodjs/web'
-import { toast } from '@redwoodjs/web/toast'
+import { Link, routes } from '@redwoodjs/router'
 
 import { useAuth } from 'src/auth'
 import { timeTag } from 'src/lib/formatters'
-
-const DELETE_PROFILE_MUTATION = gql`
-  mutation DeleteProfileMutation($id: Int!) {
-    deleteProfile(id: $id) {
-      id
-    }
-  }
-`
 
 interface Props {
   profile: NonNullable<FindProfileById['profile']>
@@ -24,22 +11,6 @@ interface Props {
 
 const Profile = ({ profile }: Props) => {
   const { currentUser } = useAuth()
-
-  const [deleteProfile] = useMutation(DELETE_PROFILE_MUTATION, {
-    onCompleted: () => {
-      toast.success('Profile deleted')
-      navigate(routes.profileSelf())
-    },
-    onError: (error) => {
-      toast.error(error.message)
-    },
-  })
-
-  const onDeleteClick = (id: DeleteProfileMutationVariables['id']) => {
-    if (confirm('Are you sure you want to delete profile ' + id + '?')) {
-      deleteProfile({ variables: { id } })
-    }
-  }
 
   return (
     <>
@@ -54,6 +25,14 @@ const Profile = ({ profile }: Props) => {
             <tr>
               <th>Id</th>
               <td>{profile.id}</td>
+            </tr>
+            <tr>
+              <th>Name</th>
+              <td>{profile.name}</td>
+            </tr>
+            <tr>
+              <th>Japanese name</th>
+              <td>{profile.japaneseName}</td>
             </tr>
             <tr>
               <th>Bio</th>

--- a/web/src/components/Profile/ProfileCell/ProfileCell.tsx
+++ b/web/src/components/Profile/ProfileCell/ProfileCell.tsx
@@ -13,6 +13,8 @@ export const QUERY = gql`
       createdAt
       updatedAt
       avatar
+      name
+      japaneseName
     }
   }
 `

--- a/web/src/components/Profile/ProfileForm/ProfileForm.tsx
+++ b/web/src/components/Profile/ProfileForm/ProfileForm.tsx
@@ -35,6 +35,36 @@ const ProfileForm = (props: ProfileFormProps) => {
         />
 
         <Label
+          name="name"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Name
+        </Label>
+
+        <TextField
+          name="name"
+          defaultValue={props.profile?.name}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
+        />
+
+        <Label
+          name="japaneseName"
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
+        >
+          Japanese name
+        </Label>
+
+        <TextField
+          name="japaneseName"
+          defaultValue={props.profile?.japaneseName}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
+        />
+
+        <Label
           name="bio"
           className="rw-label"
           errorClassName="rw-label rw-label-error"

--- a/web/src/components/Profile/ProfilesSelfCell/ProfilesSelfCell.tsx
+++ b/web/src/components/Profile/ProfilesSelfCell/ProfilesSelfCell.tsx
@@ -14,6 +14,8 @@ export const QUERY = gql`
       createdAt
       updatedAt
       avatar
+      name
+      japaneseName
     }
   }
 `

--- a/web/src/components/Reisgenootschap/Reisgenootschap.stories.tsx
+++ b/web/src/components/Reisgenootschap/Reisgenootschap.stories.tsx
@@ -1,0 +1,25 @@
+// When you've added props to your component,
+// pass Storybook's `args` through this story to control it from the addons panel:
+//
+// ```tsx
+// import type { ComponentStory } from '@storybook/react'
+//
+// export const generated: ComponentStory<typeof Reisgenootschap> = (args) => {
+//   return <Reisgenootschap {...args} />
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { ComponentMeta } from '@storybook/react'
+
+import Reisgenootschap from './Reisgenootschap'
+
+export const generated = () => {
+  return <Reisgenootschap />
+}
+
+export default {
+  title: 'Components/Reisgenootschap',
+  component: Reisgenootschap,
+} as ComponentMeta<typeof Reisgenootschap>

--- a/web/src/components/Reisgenootschap/Reisgenootschap.test.tsx
+++ b/web/src/components/Reisgenootschap/Reisgenootschap.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import Reisgenootschap from './Reisgenootschap'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('Reisgenootschap', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<Reisgenootschap />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Reisgenootschap/Reisgenootschap.tsx
+++ b/web/src/components/Reisgenootschap/Reisgenootschap.tsx
@@ -1,0 +1,42 @@
+import Person from 'src/pages/AboutPage/Person'
+
+interface IReisgenootschap {
+  id: number
+  name: string
+  profile: {
+    avatar: string
+    bio: string
+  }
+}
+
+interface IReisgenootschapProps {
+  reisgenootschap: IReisgenootschap[]
+}
+
+const Reisgenootschap = ({ reisgenootschap = [] }: IReisgenootschapProps) => {
+  {
+    /* <div className="grid gap-4 pb-4 md:grid-cols-2">
+        <Person name="Adriana" quote="エイドリアナ" story="" imgSrc={Adriana} />
+        <Person name="Drikus" quote="ドリキュス" story="" imgSrc={Drikus} />
+        <Person name="Emiel" quote="エミエル" story="" imgSrc={Emiel} />
+        <Person name="Naomi" quote="直美 なおみ" story="" imgSrc={Naomi} />
+        <Person name="Robert" quote="ロバート" story="" imgSrc={Robert} />
+      </div> */
+  }
+
+  return (
+    <div className="grid gap-4 pb-4 md:grid-cols-2">
+      {reisgenootschap.map((person) => (
+        <Person
+          key={person.id}
+          name={person.name}
+          quote=""
+          story={person.profile?.bio}
+          imgSrc={person.profile?.avatar}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default Reisgenootschap

--- a/web/src/components/Reisgenootschap/Reisgenootschap.tsx
+++ b/web/src/components/Reisgenootschap/Reisgenootschap.tsx
@@ -6,6 +6,8 @@ interface IReisgenootschap {
   profile: {
     avatar: string
     bio: string
+    name: string
+    japaneseName: string
   }
 }
 
@@ -26,13 +28,13 @@ const Reisgenootschap = ({ reisgenootschap = [] }: IReisgenootschapProps) => {
 
   return (
     <div className="grid gap-4 pb-4 md:grid-cols-2">
-      {reisgenootschap.map((person) => (
+      {reisgenootschap.map(({ id, profile }) => (
         <Person
-          key={person.id}
-          name={person.name}
-          quote=""
-          story={person.profile?.bio}
-          imgSrc={person.profile?.avatar}
+          key={id}
+          name={profile?.name}
+          quote={profile?.japaneseName}
+          story={profile?.bio}
+          imgSrc={profile?.avatar}
         />
       ))}
     </div>

--- a/web/src/components/ReisgenootschapCell/ReisgenootschapCell.mock.ts
+++ b/web/src/components/ReisgenootschapCell/ReisgenootschapCell.mock.ts
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  reisgenootschap: {
+    id: 42,
+  },
+})

--- a/web/src/components/ReisgenootschapCell/ReisgenootschapCell.stories.tsx
+++ b/web/src/components/ReisgenootschapCell/ReisgenootschapCell.stories.tsx
@@ -1,0 +1,22 @@
+import type { ComponentStory } from '@storybook/react'
+
+import { Loading, Empty, Failure, Success } from './ReisgenootschapCell'
+import { standard } from './ReisgenootschapCell.mock'
+
+export const loading = () => {
+  return Loading ? <Loading /> : <></>
+}
+
+export const empty = () => {
+  return Empty ? <Empty /> : <></>
+}
+
+export const failure: ComponentStory<typeof Failure> = (args) => {
+  return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+}
+
+export const success: ComponentStory<typeof Success> = (args) => {
+  return Success ? <Success {...standard()} {...args} /> : <></>
+}
+
+export default { title: 'Cells/ReisgenootschapCell' }

--- a/web/src/components/ReisgenootschapCell/ReisgenootschapCell.test.tsx
+++ b/web/src/components/ReisgenootschapCell/ReisgenootschapCell.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@redwoodjs/testing/web'
+import { Loading, Empty, Failure, Success } from './ReisgenootschapCell'
+import { standard } from './ReisgenootschapCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('ReisgenootschapCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success reisgenootschap={standard().reisgenootschap} />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ReisgenootschapCell/ReisgenootschapCell.tsx
+++ b/web/src/components/ReisgenootschapCell/ReisgenootschapCell.tsx
@@ -1,0 +1,41 @@
+import type {
+  FindReisgenootschapQuery,
+  FindReisgenootschapQueryVariables,
+  Role,
+} from 'types/graphql'
+
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+
+import Reisgenootschap from '../Reisgenootschap/Reisgenootschap'
+
+export const QUERY = gql`
+  query FindReisgenootschapQuery($roles: [Role!]!) {
+    usersWithRoles(roles: $roles) {
+      id
+      name
+      profile {
+        avatar
+        bio
+      }
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindReisgenootschapQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  usersWithRoles,
+}: CellSuccessProps<
+  FindReisgenootschapQuery,
+  FindReisgenootschapQueryVariables
+>) => {
+  return <Reisgenootschap reisgenootschap={usersWithRoles} />
+}

--- a/web/src/components/ReisgenootschapCell/ReisgenootschapCell.tsx
+++ b/web/src/components/ReisgenootschapCell/ReisgenootschapCell.tsx
@@ -16,6 +16,8 @@ export const QUERY = gql`
       profile {
         avatar
         bio
+        name
+        japaneseName
       }
     }
   }

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -32,15 +32,17 @@ const BlogLayout = ({ children }: BlogLayoutProps) => {
             </ul>
           </div>
         )}
-        <Link to={routes.home()} title="Ohayou Goededagu" aria-label="Home">
-          <img
-            src="/images/logo.png"
-            className="mx-auto origin-top rounded-b-full shadow-lg transition duration-500 ease-in-out hover:scale-110 hover:transform hover:shadow-xl"
-            alt="Logo Ohayo Goededagu"
-            width={128}
-            height={128}
-          />
-        </Link>
+        <div className="mx-auto w-32">
+          <Link to={routes.home()} title="Ohayou Goededagu" aria-label="Home">
+            <img
+              src="/images/logo.png"
+              className="mx-auto origin-top rounded-b-full shadow-lg transition duration-500 ease-in-out hover:scale-110 hover:transform hover:shadow-xl"
+              alt="Logo Ohayo Goededagu"
+              width={128}
+              height={128}
+            />
+          </Link>
+        </div>
         <h1 className="pt-3 text-3xl font-bold">
           Ohayou Goededagu | おはよ グデダギュ
         </h1>

--- a/web/src/pages/AboutPage/AboutPage.tsx
+++ b/web/src/pages/AboutPage/AboutPage.tsx
@@ -1,25 +1,23 @@
-import { Link, routes } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
+
+import { Role } from 'src/types/role'
 
 import Adriana from '../../../../web/public/images/Adriana.jpg'
 import Drikus from '../../../../web/public/images/Drikus.jpg'
 import Emiel from '../../../../web/public/images/Emiel.jpg'
 import Naomi from '../../../../web/public/images/Naomi.jpg'
 import Robert from '../../../../web/public/images/Robert.jpg'
+import ReisgenootschapCell from '../../components/ReisgenootschapCell'
 
 import Person from './Person'
+
+const reisgenootschapRoles = [Role.ADMIN, Role.MODERATOR]
 
 const AboutPage = () => {
   return (
     <>
       <MetaTags title="About" description="About page" />
-      <div className="grid gap-4 pb-4 md:grid-cols-2">
-        <Person name="Adriana" quote="エイドリアナ" story="" imgSrc={Adriana} />
-        <Person name="Drikus" quote="ドリキュス" story="" imgSrc={Drikus} />
-        <Person name="Emiel" quote="エミエル" story="" imgSrc={Emiel} />
-        <Person name="Naomi" quote="直美 なおみ" story="" imgSrc={Naomi} />
-        <Person name="Robert" quote="ロバート" story="" imgSrc={Robert} />
-      </div>
+      <ReisgenootschapCell roles={reisgenootschapRoles} />
     </>
   )
 }

--- a/web/src/pages/AboutPage/AboutPage.tsx
+++ b/web/src/pages/AboutPage/AboutPage.tsx
@@ -2,14 +2,7 @@ import { MetaTags } from '@redwoodjs/web'
 
 import { Role } from 'src/types/role'
 
-import Adriana from '../../../../web/public/images/Adriana.jpg'
-import Drikus from '../../../../web/public/images/Drikus.jpg'
-import Emiel from '../../../../web/public/images/Emiel.jpg'
-import Naomi from '../../../../web/public/images/Naomi.jpg'
-import Robert from '../../../../web/public/images/Robert.jpg'
 import ReisgenootschapCell from '../../components/ReisgenootschapCell'
-
-import Person from './Person'
 
 const reisgenootschapRoles = [Role.ADMIN, Role.MODERATOR]
 


### PR DESCRIPTION
This PR does multiple things:
- Add `name` and `japaneseName` properties to the `Profile` model
- Allow the user to edit those properties
- Deprecate the `name` property on the `User` model
- Show the reisgenootschap in the `Reisgenootschap`, which are users with the roles `ADMIN` or `MODERATOR` and their profiles

Resolves #34 