### PR TITLE
feat: Disable thumb buttons while waiting for flow to complete

### DIFF
--- a/web/src/components/Comment/Comment.tsx
+++ b/web/src/components/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { BsTrash } from 'react-icons/bs'
 import type { Comment } from 'types/graphql'
@@ -40,6 +40,11 @@ export default ({ comment }: ICommentProps) => {
   const { currentUser } = useAuth()
 
   const [deleteFadeOut, setDeleteFadeOut] = useState(false)
+  const [thumbsDisabled, setThumbsDisabled] = useState(false)
+
+  useEffect(() => {
+    setThumbsDisabled(false)
+  }, [comment?.thumbs])
 
   const [createUpdateOrDeleteThumb] = useMutation(
     CREATE_UPDATE_OR_DELETE_THUMB,
@@ -108,6 +113,9 @@ export default ({ comment }: ICommentProps) => {
   }, [rating])
 
   const handleThumbClick = (up: boolean) => {
+    if (!thumbsDisabled) {
+      setThumbsDisabled(true)
+    }
     createUpdateOrDeleteThumb({
       variables: { input: { commentId: comment.id, up } },
     })
@@ -150,6 +158,7 @@ export default ({ comment }: ICommentProps) => {
             thumbs={comment.thumbs}
             entityId={comment.id}
             onThumb={handleThumbClick}
+            disabled={thumbsDisabled}
           />
         </div>
       </div>

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -1,3 +1,5 @@
+import { classNames } from 'src/lib/class-names'
+
 import Button from '../Button/Button'
 
 interface IThumbProps {
@@ -5,11 +7,19 @@ interface IThumbProps {
   active?: boolean
   count: number
   onClick: () => void
+  disabled?: boolean
 }
 
-const Thumb = ({ up, active, count, onClick }: IThumbProps) => {
+const Thumb = ({ up, active, count, onClick, disabled }: IThumbProps) => {
   return (
-    <Button onClick={onClick} variant={active ? 'filled' : 'outlined'}>
+    <Button
+      onClick={disabled ? undefined : onClick}
+      variant={active ? 'filled' : 'outlined'}
+      className={classNames(
+        'transition-filter',
+        disabled ? 'cursor-not-allowed grayscale' : ''
+      )}
+    >
       {up ? '👍' : '👎'} {count}
     </Button>
   )

--- a/web/src/components/Thumbs/Thumbs.tsx
+++ b/web/src/components/Thumbs/Thumbs.tsx
@@ -8,6 +8,7 @@ export interface IThumbProps {
   thumbs: Thumbs[]
   entityId: number
   onThumb: (up: boolean) => void
+  disabled?: boolean
 }
 
 const Thumbs = (props: IThumbProps) => {
@@ -41,12 +42,14 @@ const Thumbs = (props: IThumbProps) => {
         count={upCount}
         active={currentUserThumb?.up}
         onClick={() => props.onThumb(true)}
+        disabled={props.disabled}
       />
       <Thumb
         up={false}
         count={downCount}
         active={currentUserThumb?.up === false}
         onClick={() => props.onThumb(false)}
+        disabled={props.disabled}
       />
     </div>
   )


### PR DESCRIPTION
Currently the buttons can be clicked multiple times which can cause errors and/or race conditions. This change disables the button after you pressed it until the new situation has been loaded allowing for a better experience