### PR TITLE
Video page #47

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -50,6 +50,7 @@ const Routes = () => {
         <Private unauthenticated="login">
           <Route path="/" page={HomePage} name="home" prerender />
           <Route path="/article/{id:Int}" page={ArticlePage} name="article" />
+          <Route path="/vlog" page={VlogPage} name="vlog" />
         </Private>
         <Route path="/login" page={LoginPage} name="login" />
         <Route path="/signup" page={SignupPage} name="signup" />

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -3,6 +3,7 @@ import type { ArticlesQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 import ArticlePreview from '../Article/components/ArticlePreview'
+import { EPostType } from '../ArticleTypeIcon/ArticleTypeIcon'
 import Skeleton from '../Skeleton/Skeleton'
 
 export const QUERY = gql`
@@ -32,6 +33,12 @@ export const QUERY = gql`
     }
   }
 `
+
+interface Props {
+  vlog?: boolean
+  articles: CellSuccessProps<ArticlesQuery>
+}
+
 export const Loading = () => (
   <div className="grid max-w-6xl">
     {Array.from({ length: 5 }).map((_, i) => (
@@ -48,7 +55,23 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({ articles, vlog }: Props) => {
+  const vlogs = articles.filter((article) => {
+    if (article.type === EPostType.VIDEO) {
+      return article
+    }
+  })
+
+  if (vlog) {
+    return (
+      <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
+        {vlogs.map((article) => {
+          return <ArticlePreview key={article.id} article={article} />
+        })}
+      </ul>
+    )
+  }
+
   return (
     <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
       {articles.map((article) => {

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -107,6 +107,11 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
               </Link>
             </li>
             <li>
+              <Link className="rw-button" to={routes.vlog()}>
+                Vlog
+              </Link>
+            </li>
+            <li>
               <Link className="rw-button" to={routes.about()}>
                 Reisgenootschap
               </Link>

--- a/web/src/pages/VlogPage/VlogPage.tsx
+++ b/web/src/pages/VlogPage/VlogPage.tsx
@@ -1,0 +1,14 @@
+import { MetaTags } from '@redwoodjs/web'
+
+import ArticlesCell from 'src/components/ArticlesCell'
+
+const VlogPage = () => {
+  return (
+    <>
+      <MetaTags title="Vlog" description="Vlog page" />
+      <ArticlesCell vlog />
+    </>
+  )
+}
+
+export default VlogPage


### PR DESCRIPTION
I added an extra navigation button to display a page that only shows the video posts.

How to test:
- [ ] Click on the 'vlog' button on the homepage
- [ ] See that the page only displays the video posts
- [ ] Click on a video post to see that it also still navigates to the individual video posts page