### PR TITLE
Feat/77 preview post

### DIFF
--- a/web/src/components/Article/Article.tsx
+++ b/web/src/components/Article/Article.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 const Article = ({ article }: Props) => {
   const { currentUser } = useAuth()
-  const isUserAuthor = article.user.id === currentUser?.id
+  const isUserAuthor = article?.user?.id === currentUser?.id
 
   const formattedDate = new Date(article.createdAt).toLocaleString('nl-NL', {
     day: '2-digit',
@@ -36,20 +36,22 @@ const Article = ({ article }: Props) => {
   })
 
   const sortedComments = useMemo(() => {
-    return [...article.comments].sort((a, b) => {
-      const aUpVotes = a.thumbs.filter((t) => t.up).length
-      const aDownVotes = a.thumbs.filter((t) => !t.up).length
+    if (article.comments) {
+      return [...article.comments].sort((a, b) => {
+        const aUpVotes = a.thumbs.filter((t) => t.up).length
+        const aDownVotes = a.thumbs.filter((t) => !t.up).length
 
-      const bUpVotes = b.thumbs.filter((t) => t.up).length
-      const bDownVotes = b.thumbs.filter((t) => !t.up).length
+        const bUpVotes = b.thumbs.filter((t) => t.up).length
+        const bDownVotes = b.thumbs.filter((t) => !t.up).length
 
-      const scoreA = hotScore(aUpVotes, aDownVotes, new Date(a.createdAt))
-      const scoreB = hotScore(bUpVotes, bDownVotes, new Date(b.createdAt))
+        const scoreA = hotScore(aUpVotes, aDownVotes, new Date(a.createdAt))
+        const scoreB = hotScore(bUpVotes, bDownVotes, new Date(b.createdAt))
 
-      if (scoreA > scoreB) return -1
-      if (scoreA < scoreB) return 1
-      return 0
-    })
+        if (scoreA > scoreB) return -1
+        if (scoreA < scoreB) return 1
+        return 0
+      })
+    }
   }, [article.comments])
 
   return (
@@ -102,26 +104,28 @@ const Article = ({ article }: Props) => {
         </div>
       )}
 
-      <div>
-        <h2 className="mt-5 text-2xl font-light text-gray-600">Comments</h2>
-        <ul className="mt-3 max-w-xl">
-          {sortedComments.length > 0 ? (
-            sortedComments.map((comment) => (
-              <li key={comment.id} className="mb-4">
-                <Comment comment={comment} />
-              </li>
-            ))
-          ) : (
-            <div className="flex flex-col gap-2 rounded-md bg-gray-100 p-3">
-              <p className=" text-gray-500">No comments yet. 🙃</p>
-              <p className=" text-gray-500">Be the first! 😻</p>
-            </div>
-          )}
-        </ul>
-        <div className="mt-5">
-          <CommentForm postId={article.id} />
+      {sortedComments && (
+        <div>
+          <h2 className="mt-5 text-2xl font-light text-gray-600">Comments</h2>
+          <ul className="mt-3 max-w-xl">
+            {sortedComments.length > 0 ? (
+              sortedComments.map((comment) => (
+                <li key={comment.id} className="mb-4">
+                  <Comment comment={comment} />
+                </li>
+              ))
+            ) : (
+              <div className="flex flex-col gap-2 rounded-md bg-gray-100 p-3">
+                <p className=" text-gray-500">No comments yet. 🙃</p>
+                <p className=" text-gray-500">Be the first! 😻</p>
+              </div>
+            )}
+          </ul>
+          <div className="mt-5">
+            <CommentForm postId={article.id} />
+          </div>
         </div>
-      </div>
+      )}
     </article>
   )
 }

--- a/web/src/components/Article/components/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle.tsx
@@ -104,7 +104,7 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
             }}
             className="rounded bg-gray-400 bg-cover bg-center bg-no-repeat bg-blend-multiply"
           >
-            <div className="mx-auto flex aspect-video max-w-screen-xl flex-col justify-end px-4">
+            <div className="flex aspect-video max-w-screen-xl flex-col justify-end px-4">
               <div className="flex flex-row items-center justify-start gap-2">
                 <div>
                   <ArticleTypeIcon type={article.type as EPostType} />

--- a/web/src/components/Article/components/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle.tsx
@@ -24,6 +24,8 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
   const authorName =
     article.user.profile?.name || article.user.name || 'Anonymous'
 
+  console.log('article', article)
+
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
@@ -77,7 +79,7 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
                   </span>
                 </div>
               </div>
-              {article.comments.length > 0 && (
+              {article?.comments?.length > 0 && (
                 <ArticleCommentCountBadge count={article.comments.length} />
               )}
               <Link

--- a/web/src/components/Article/components/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle.tsx
@@ -24,8 +24,6 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
   const authorName =
     article.user.profile?.name || article.user.name || 'Anonymous'
 
-  console.log('article', article)
-
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (

--- a/web/src/components/Article/components/ArticleChotto.tsx
+++ b/web/src/components/Article/components/ArticleChotto.tsx
@@ -42,7 +42,7 @@ const ArticleChotto = ({ article, displayType, date }: Props) => {
               <div className="justmt-2 line-clamp-5">{article.body}</div>
               <div className="flex items-center justify-between pt-4">
                 <AvatarTimestamp article={article} />
-                {article.comments.length > 0 && (
+                {article?.comments?.length > 0 && (
                   <ArticleCommentCountBadge
                     count={article.comments.length}
                     variant="dark"

--- a/web/src/components/Article/components/ArticleHaiku.tsx
+++ b/web/src/components/Article/components/ArticleHaiku.tsx
@@ -42,7 +42,7 @@ const ArticleHaiku = ({ article, displayType, date }: Props) => {
               <div className="justmt-2 line-clamp-5">{article.body}</div>
               <div className="flex items-center justify-between pt-4">
                 <AvatarTimestamp article={article} />
-                {article.comments.length > 0 && (
+                {article?.comments?.length > 0 && (
                   <ArticleCommentCountBadge
                     count={article.comments.length}
                     variant="dark"

--- a/web/src/components/Article/components/ArticleVideo.tsx
+++ b/web/src/components/Article/components/ArticleVideo.tsx
@@ -47,7 +47,7 @@ const ArticleVideo = ({ article, displayType, date }: Props) => {
           <div className="flex flex-row items-center justify-between pt-4">
             <AvatarTimestamp article={article} />
             <div className="flex items-center gap-6">
-              {article.comments.length > 0 && (
+              {article?.comments?.length > 0 && (
                 <ArticleCommentCountBadge
                   count={article.comments.length}
                   variant="dark"

--- a/web/src/components/Post/PostForm/PostForm.tsx
+++ b/web/src/components/Post/PostForm/PostForm.tsx
@@ -168,28 +168,26 @@ const PostForm = (props: PostFormProps) => {
           )}
 
           {postType === EPostType.ARTICLE && (
-            <>
-              <Upload
-                name="coverImage"
-                multiple={false}
-                setCoverImage={({ public_id, secure_url }) =>
-                  setCoverImage({
-                    imageId: public_id,
-                    url: secure_url,
-                  })
-                }
-              />
-
-              <Preview
-                profile={props.profile}
-                post={props.post}
-                postType={postType}
-                postTitle={postTitle}
-                postBody={postBody}
-                coverImage={coverImage?.url}
-              />
-            </>
+            <Upload
+              name="coverImage"
+              multiple={false}
+              setCoverImage={({ public_id, secure_url }) =>
+                setCoverImage({
+                  imageId: public_id,
+                  url: secure_url,
+                })
+              }
+            />
           )}
+
+          <Preview
+            profile={props.profile}
+            post={props.post}
+            postType={postType}
+            postTitle={postTitle}
+            postBody={postBody}
+            coverImage={coverImage?.url}
+          />
 
           <div className="rw-button-group gap-0">
             <Button

--- a/web/src/components/Post/PostForm/PostForm.tsx
+++ b/web/src/components/Post/PostForm/PostForm.tsx
@@ -155,16 +155,10 @@ const PostForm = (props: PostFormProps) => {
           </SelectField>
 
           {postType === EPostType.VIDEO && (
-            <>
-              <VideoForm
-                videoPostFormData={videoPostFormData}
-                setVideoPostFormData={setVideoPostFormData}
-              />
-
-              <div className="mt-4">
-                <Video embedUrl={videoPostFormData?.videoUrl} />
-              </div>
-            </>
+            <VideoForm
+              videoPostFormData={videoPostFormData}
+              setVideoPostFormData={setVideoPostFormData}
+            />
           )}
 
           {postType === EPostType.ARTICLE && (
@@ -187,6 +181,7 @@ const PostForm = (props: PostFormProps) => {
             postTitle={postTitle}
             postBody={postBody}
             coverImage={coverImage?.url}
+            videoPost={videoPostFormData}
           />
 
           <div className="rw-button-group gap-0">

--- a/web/src/components/Upload/Preview/Preview.tsx
+++ b/web/src/components/Upload/Preview/Preview.tsx
@@ -6,7 +6,7 @@ import {
 
 import { Label } from '@redwoodjs/forms'
 
-import ArticleCell from 'src/components/ArticleCell'
+import Article from 'src/components/Article/Article'
 import { classNames } from 'src/lib/class-names'
 
 import ArticleTypeIcon, {
@@ -50,6 +50,20 @@ const Preview = ({
     minute: '2-digit',
   })
 
+  const url = {
+    url: coverImage,
+  }
+
+  const article = {
+    id: post?.id ? post?.id : '',
+    title: postTitle,
+    body: postBody,
+    type: postType,
+    createdAt: post?.createdAt ? post?.createdAt : formattedCurrentDate,
+    coverImage: url,
+    user: profile,
+  }
+
   return (
     <>
       <Label
@@ -57,7 +71,7 @@ const Preview = ({
         className="rw-label"
         errorClassName="rw-label rw-label-error"
       >
-        Cover image preview for:
+        Article preview for:
       </Label>
       <div className="mt-2 flex flex-row gap-0">
         <Button
@@ -88,7 +102,11 @@ const Preview = ({
         </Button>
       </div>
 
-      {!blogRollPreview && <ArticleCell id={post.id} />}
+      {!blogRollPreview && (
+        <div className="my-2 rounded bg-gray-300">
+          <Article article={article} />
+        </div>
+      )}
 
       {blogRollPreview && (
         <div className="mt-2 grid max-w-6xl">

--- a/web/src/components/Upload/Preview/Preview.tsx
+++ b/web/src/components/Upload/Preview/Preview.tsx
@@ -6,6 +6,7 @@ import {
 
 import { Label } from '@redwoodjs/forms'
 
+import ArticleCell from 'src/components/ArticleCell'
 import { classNames } from 'src/lib/class-names'
 
 import ArticleTypeIcon, {
@@ -87,37 +88,7 @@ const Preview = ({
         </Button>
       </div>
 
-      {!blogRollPreview && (
-        <div className="mt-2 grid max-w-6xl">
-          <section
-            style={{
-              backgroundImage: coverImage
-                ? `url(${coverImage})`
-                : `url(/images/logo-full.png)`,
-            }}
-            className="rounded bg-gray-400 bg-cover bg-center bg-no-repeat bg-blend-multiply"
-          >
-            <div className="mx-auto flex aspect-video max-w-screen-xl flex-col justify-end px-4">
-              <div className="flex flex-row items-center justify-start gap-2">
-                <div>
-                  <ArticleTypeIcon type={postType as EPostType} />
-                </div>
-                <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase leading-none tracking-tight text-white drop-shadow-xl md:gap-4 md:text-5xl lg:text-6xl">
-                  {postTitle ? postTitle : 'Title'}
-                </h1>
-              </div>
-              <div className="flex flex-row items-center gap-2 pb-2">
-                <span className="text-sm text-slate-200">
-                  {profile?.name ? profile?.name : 'Your name'}
-                </span>
-                <span className="text-sm text-slate-200">
-                  | {post?.createdAt ? formattedDate : formattedCurrentDate}
-                </span>
-              </div>
-            </div>
-          </section>
-        </div>
-      )}
+      {!blogRollPreview && <ArticleCell id={post.id} />}
 
       {blogRollPreview && (
         <div className="mt-2 grid max-w-6xl">

--- a/web/src/components/Upload/Preview/Preview.tsx
+++ b/web/src/components/Upload/Preview/Preview.tsx
@@ -16,6 +16,7 @@ interface Props {
   postTitle: string
   postBody: string
   coverImage?: string
+  videoPost: object
 }
 
 const Preview = ({
@@ -25,6 +26,7 @@ const Preview = ({
   postType,
   postTitle,
   postBody,
+  videoPost,
 }: Props) => {
   const [blogRollPreview, setBlogRollPreview] = React.useState<boolean>(false)
 
@@ -48,6 +50,7 @@ const Preview = ({
     createdAt: post?.createdAt ? post?.createdAt : formattedCurrentDate,
     coverImage: url,
     user: profile,
+    videoPost: videoPost,
   }
 
   return (

--- a/web/src/components/Upload/Preview/Preview.tsx
+++ b/web/src/components/Upload/Preview/Preview.tsx
@@ -1,8 +1,4 @@
-import {
-  BsArrowRightCircle,
-  BsFillCheckCircleFill,
-  BsFillCircleFill,
-} from 'react-icons/bs'
+import { BsFillCheckCircleFill, BsFillCircleFill } from 'react-icons/bs'
 
 import { Label } from '@redwoodjs/forms'
 
@@ -10,10 +6,7 @@ import Article from 'src/components/Article/Article'
 import ArticlePreview from 'src/components/Article/components/ArticlePreview'
 import { classNames } from 'src/lib/class-names'
 
-import ArticleTypeIcon, {
-  EPostType,
-} from '../../ArticleTypeIcon/ArticleTypeIcon'
-import Avatar from '../../Avatar/Avatar'
+import { EPostType } from '../../ArticleTypeIcon/ArticleTypeIcon'
 import Button from '../../Button/Button'
 
 interface Props {
@@ -36,14 +29,6 @@ const Preview = ({
   const [blogRollPreview, setBlogRollPreview] = React.useState<boolean>(false)
 
   const formattedCurrentDate = new Date().toLocaleString('nl-NL', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-
-  const formattedDate = new Date(post?.createdAt).toLocaleString('nl-NL', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/web/src/components/Upload/Preview/Preview.tsx
+++ b/web/src/components/Upload/Preview/Preview.tsx
@@ -7,6 +7,7 @@ import {
 import { Label } from '@redwoodjs/forms'
 
 import Article from 'src/components/Article/Article'
+import ArticlePreview from 'src/components/Article/components/ArticlePreview'
 import { classNames } from 'src/lib/class-names'
 
 import ArticleTypeIcon, {
@@ -102,62 +103,10 @@ const Preview = ({
         </Button>
       </div>
 
-      {!blogRollPreview && (
-        <div className="my-2 rounded bg-gray-300">
-          <Article article={article} />
-        </div>
-      )}
-
-      {blogRollPreview && (
-        <div className="mt-2 grid max-w-6xl">
-          <section
-            style={{
-              backgroundImage: coverImage
-                ? `url(${coverImage})`
-                : `url(/images/logo-full.png)`,
-            }}
-            className="rounded bg-gray-600 bg-cover bg-center bg-no-repeat bg-blend-multiply"
-          >
-            <div className="mx-auto max-w-screen-xl px-4 py-20 md:py-24 lg:py-56">
-              <div className="flex flex-row items-center justify-center gap-2 pb-2">
-                <div>
-                  <ArticleTypeIcon type={postType as EPostType} />
-                </div>
-
-                <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
-                  {postTitle ? postTitle : 'Title'}
-                </h1>
-              </div>
-              <p className="mb-8 line-clamp-3 text-center text-lg font-normal text-gray-300 sm:px-16 lg:px-48 lg:text-xl">
-                {postBody}
-              </p>
-              <div className="flex flex-row items-center justify-center gap-12">
-                <div className="flex flex-row items-center gap-2">
-                  <Avatar
-                    src={profile?.avatar}
-                    alt={profile?.name}
-                    name={profile?.name}
-                  />
-                  <div className="flex flex-col items-start">
-                    <span className="text-sm text-slate-300">
-                      {profile?.name ? profile?.name : 'Your name'}
-                    </span>
-                    <span className="text-sm text-slate-300">
-                      {post?.createdAt ? formattedDate : formattedCurrentDate}
-                    </span>
-                  </div>
-                </div>
-                <a className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400">
-                  <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
-                    <span className="hidden sm:inline-block">Lees verder</span>
-                    <BsArrowRightCircle />
-                  </Button>
-                </a>
-              </div>
-            </div>
-          </section>
-        </div>
-      )}
+      <div className="my-2 rounded bg-gray-300">
+        {!blogRollPreview && <Article article={article} />}
+        {blogRollPreview && <ArticlePreview article={article} />}
+      </div>
     </>
   )
 }


### PR DESCRIPTION
I made it so you can view a preview of your entire post when editing or creating it, not just the cover image. This fixes the nice to have issue #77 

While doing this I also reduced the code by removing double code and instead reusing the existing article components.

It should work for all article types we currently have: article, haiku, chotto & video