### PR TITLE
Added: Add Image gallery backend

### DIFF
--- a/api/db/migrations/20230903194437_add_image_gallery_for_post_models/migration.sql
+++ b/api/db/migrations/20230903194437_add_image_gallery_for_post_models/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "ImageGallery" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+
+    CONSTRAINT "ImageGallery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ImageGalleryOnPost" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageGalleryId" INTEGER NOT NULL,
+    "postId" INTEGER NOT NULL,
+
+    CONSTRAINT "ImageGalleryOnPost_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ImageGalleryOnPost" ADD CONSTRAINT "ImageGalleryOnPost_imageGalleryId_fkey" FOREIGN KEY ("imageGalleryId") REFERENCES "ImageGallery"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImageGalleryOnPost" ADD CONSTRAINT "ImageGalleryOnPost_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/migrations/20230903203946_add_image_gallery_image/migration.sql
+++ b/api/db/migrations/20230903203946_add_image_gallery_image/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `imageId` on the `ImageGallery` table. All the data in the column will be lost.
+  - You are about to drop the column `url` on the `ImageGallery` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "ImageGallery" DROP COLUMN "imageId",
+DROP COLUMN "url";
+
+-- CreateTable
+CREATE TABLE "ImageGalleryImage" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "imageGalleryId" INTEGER NOT NULL,
+
+    CONSTRAINT "ImageGalleryImage_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ImageGalleryImage" ADD CONSTRAINT "ImageGalleryImage_imageGalleryId_fkey" FOREIGN KEY ("imageGalleryId") REFERENCES "ImageGallery"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/db/migrations/20230903205554_add_name_property_to_image_gallery/migration.sql
+++ b/api/db/migrations/20230903205554_add_name_property_to_image_gallery/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ImageGallery" ADD COLUMN     "name" TEXT;

--- a/api/db/migrations/20230903205700_add_description_property_to_image_gallery/migration.sql
+++ b/api/db/migrations/20230903205700_add_description_property_to_image_gallery/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ImageGallery" ADD COLUMN     "description" TEXT;

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -124,6 +124,8 @@ model ImageGallery {
   createdAt          DateTime             @default(now())
   ImageGalleryOnPost ImageGalleryOnPost[]
   images             ImageGalleryImage[]
+  name               String?
+  description        String?
 }
 
 model ImageGalleryOnPost {

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -39,18 +39,19 @@ model Profile {
 }
 
 model Post {
-  id           Int        @id @default(autoincrement())
-  title        String
-  body         String?
-  createdAt    DateTime   @default(now())
-  user         User       @relation(fields: [userId], references: [id])
-  userId       Int
-  published    Boolean    @default(false)
-  type         PostType   @default(ARTICLE)
-  comments     Comment[]
-  videoPost    VideoPost?
-  coverImage   Image?     @relation(fields: [coverImageId], references: [id])
-  coverImageId Int?
+  id                 Int                  @id @default(autoincrement())
+  title              String
+  body               String?
+  createdAt          DateTime             @default(now())
+  user               User                 @relation(fields: [userId], references: [id])
+  userId             Int
+  published          Boolean              @default(false)
+  type               PostType             @default(ARTICLE)
+  comments           Comment[]
+  videoPost          VideoPost?
+  coverImage         Image?               @relation(fields: [coverImageId], references: [id])
+  coverImageId       Int?
+  ImageGalleryOnPost ImageGalleryOnPost[]
 }
 
 model VideoPost {
@@ -107,4 +108,21 @@ model Image {
   url       String
   postId    Int
   Post      Post[]
+}
+
+model ImageGallery {
+  id                 Int                  @id @default(autoincrement())
+  createdAt          DateTime             @default(now())
+  imageId            String
+  url                String
+  ImageGalleryOnPost ImageGalleryOnPost[]
+}
+
+model ImageGalleryOnPost {
+  id             Int          @id @default(autoincrement())
+  createdAt      DateTime     @default(now())
+  imageGalleryId Int
+  imageGallery   ImageGallery @relation(fields: [imageGalleryId], references: [id])
+  postId         Int
+  post           Post         @relation(fields: [postId], references: [id])
 }

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -39,19 +39,19 @@ model Profile {
 }
 
 model Post {
-  id                 Int                  @id @default(autoincrement())
-  title              String
-  body               String?
-  createdAt          DateTime             @default(now())
-  user               User                 @relation(fields: [userId], references: [id])
-  userId             Int
-  published          Boolean              @default(false)
-  type               PostType             @default(ARTICLE)
-  comments           Comment[]
-  videoPost          VideoPost?
-  coverImage         Image?               @relation(fields: [coverImageId], references: [id])
-  coverImageId       Int?
-  ImageGalleryOnPost ImageGalleryOnPost[]
+  id             Int                  @id @default(autoincrement())
+  title          String
+  body           String?
+  createdAt      DateTime             @default(now())
+  user           User                 @relation(fields: [userId], references: [id])
+  userId         Int
+  published      Boolean              @default(false)
+  type           PostType             @default(ARTICLE)
+  comments       Comment[]
+  videoPost      VideoPost?
+  coverImage     Image?               @relation(fields: [coverImageId], references: [id])
+  coverImageId   Int?
+  imageGalleries ImageGalleryOnPost[]
 }
 
 model VideoPost {

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -110,12 +110,20 @@ model Image {
   Post      Post[]
 }
 
+model ImageGalleryImage {
+  id             Int          @id @default(autoincrement())
+  createdAt      DateTime     @default(now())
+  imageId        String
+  url            String
+  imageGalleryId Int
+  imageGallery   ImageGallery @relation(fields: [imageGalleryId], references: [id])
+}
+
 model ImageGallery {
   id                 Int                  @id @default(autoincrement())
   createdAt          DateTime             @default(now())
-  imageId            String
-  url                String
   ImageGalleryOnPost ImageGalleryOnPost[]
+  images             ImageGalleryImage[]
 }
 
 model ImageGalleryOnPost {

--- a/api/src/graphql/imageGalleries.sdl.ts
+++ b/api/src/graphql/imageGalleries.sdl.ts
@@ -1,0 +1,34 @@
+export const schema = gql`
+  type ImageGallery {
+    id: Int!
+    createdAt: DateTime!
+    imageId: String!
+    url: String!
+    ImageGalleryOnPost: [ImageGalleryOnPost]!
+  }
+
+  type Query {
+    imageGalleries: [ImageGallery!]! @requireAuth
+    imageGallery(id: Int!): ImageGallery @requireAuth
+  }
+
+  input CreateImageGalleryInput {
+    imageId: String!
+    url: String!
+  }
+
+  input UpdateImageGalleryInput {
+    imageId: String
+    url: String
+  }
+
+  type Mutation {
+    createImageGallery(input: CreateImageGalleryInput!): ImageGallery!
+      @requireAuth
+    updateImageGallery(
+      id: Int!
+      input: UpdateImageGalleryInput!
+    ): ImageGallery! @requireAuth
+    deleteImageGallery(id: Int!): ImageGallery! @requireAuth
+  }
+`

--- a/api/src/graphql/imageGalleries.sdl.ts
+++ b/api/src/graphql/imageGalleries.sdl.ts
@@ -2,9 +2,10 @@ export const schema = gql`
   type ImageGallery {
     id: Int!
     createdAt: DateTime!
-    imageId: String!
-    url: String!
     ImageGalleryOnPost: [ImageGalleryOnPost]!
+    images: [ImageGalleryImage]!
+    name: String
+    description: String
   }
 
   type Query {
@@ -13,13 +14,13 @@ export const schema = gql`
   }
 
   input CreateImageGalleryInput {
-    imageId: String!
-    url: String!
+    name: String
+    description: String
   }
 
   input UpdateImageGalleryInput {
-    imageId: String
-    url: String
+    name: String
+    description: String
   }
 
   type Mutation {

--- a/api/src/graphql/imageGalleryImages.sdl.ts
+++ b/api/src/graphql/imageGalleryImages.sdl.ts
@@ -1,0 +1,38 @@
+export const schema = gql`
+  type ImageGalleryImage {
+    id: Int!
+    createdAt: DateTime!
+    imageId: String!
+    url: String!
+    imageGalleryId: Int!
+    imageGallery: ImageGallery!
+  }
+
+  type Query {
+    imageGalleryImages: [ImageGalleryImage!]! @requireAuth
+    imageGalleryImage(id: Int!): ImageGalleryImage @requireAuth
+  }
+
+  input CreateImageGalleryImageInput {
+    imageId: String!
+    url: String!
+    imageGalleryId: Int!
+  }
+
+  input UpdateImageGalleryImageInput {
+    imageId: String
+    url: String
+    imageGalleryId: Int
+  }
+
+  type Mutation {
+    createImageGalleryImage(
+      input: CreateImageGalleryImageInput!
+    ): ImageGalleryImage! @requireAuth
+    updateImageGalleryImage(
+      id: Int!
+      input: UpdateImageGalleryImageInput!
+    ): ImageGalleryImage! @requireAuth
+    deleteImageGalleryImage(id: Int!): ImageGalleryImage! @requireAuth
+  }
+`

--- a/api/src/graphql/imageGalleryOnPosts.sdl.ts
+++ b/api/src/graphql/imageGalleryOnPosts.sdl.ts
@@ -1,0 +1,36 @@
+export const schema = gql`
+  type ImageGalleryOnPost {
+    id: Int!
+    createdAt: DateTime!
+    imageGalleryId: Int!
+    imageGallery: ImageGallery!
+    postId: Int!
+    post: Post!
+  }
+
+  type Query {
+    imageGalleryOnPosts: [ImageGalleryOnPost!]! @requireAuth
+    imageGalleryOnPost(id: Int!): ImageGalleryOnPost @requireAuth
+  }
+
+  input CreateImageGalleryOnPostInput {
+    imageGalleryId: Int!
+    postId: Int!
+  }
+
+  input UpdateImageGalleryOnPostInput {
+    imageGalleryId: Int
+    postId: Int
+  }
+
+  type Mutation {
+    createImageGalleryOnPost(
+      input: CreateImageGalleryOnPostInput!
+    ): ImageGalleryOnPost! @requireAuth
+    updateImageGalleryOnPost(
+      id: Int!
+      input: UpdateImageGalleryOnPostInput!
+    ): ImageGalleryOnPost! @requireAuth
+    deleteImageGalleryOnPost(id: Int!): ImageGalleryOnPost! @requireAuth
+  }
+`

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -11,6 +11,7 @@ export const schema = gql`
     comments: [Comment]!
     videoPost: VideoPost
     coverImage: Image
+    imageGalleries: [ImageGalleryOnPost]!
   }
 
   type Query {

--- a/api/src/services/imageGalleries/imageGalleries.scenarios.ts
+++ b/api/src/services/imageGalleries/imageGalleries.scenarios.ts
@@ -1,0 +1,11 @@
+import type { Prisma, ImageGallery } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.ImageGalleryCreateArgs>({
+  imageGallery: {
+    one: { data: { imageId: 'String', url: 'String' } },
+    two: { data: { imageId: 'String', url: 'String' } },
+  },
+})
+
+export type StandardScenario = ScenarioData<ImageGallery, 'imageGallery'>

--- a/api/src/services/imageGalleries/imageGalleries.scenarios.ts
+++ b/api/src/services/imageGalleries/imageGalleries.scenarios.ts
@@ -2,10 +2,7 @@ import type { Prisma, ImageGallery } from '@prisma/client'
 import type { ScenarioData } from '@redwoodjs/testing/api'
 
 export const standard = defineScenario<Prisma.ImageGalleryCreateArgs>({
-  imageGallery: {
-    one: { data: { imageId: 'String', url: 'String' } },
-    two: { data: { imageId: 'String', url: 'String' } },
-  },
+  imageGallery: { one: { data: {} }, two: { data: {} } },
 })
 
 export type StandardScenario = ScenarioData<ImageGallery, 'imageGallery'>

--- a/api/src/services/imageGalleries/imageGalleries.test.ts
+++ b/api/src/services/imageGalleries/imageGalleries.test.ts
@@ -1,0 +1,63 @@
+import type { ImageGallery } from '@prisma/client'
+
+import {
+  imageGalleries,
+  imageGallery,
+  createImageGallery,
+  updateImageGallery,
+  deleteImageGallery,
+} from './imageGalleries'
+import type { StandardScenario } from './imageGalleries.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('imageGalleries', () => {
+  scenario('returns all imageGalleries', async (scenario: StandardScenario) => {
+    const result = await imageGalleries()
+
+    expect(result.length).toEqual(Object.keys(scenario.imageGallery).length)
+  })
+
+  scenario(
+    'returns a single imageGallery',
+    async (scenario: StandardScenario) => {
+      const result = await imageGallery({ id: scenario.imageGallery.one.id })
+
+      expect(result).toEqual(scenario.imageGallery.one)
+    }
+  )
+
+  scenario('creates a imageGallery', async () => {
+    const result = await createImageGallery({
+      input: { imageId: 'String', url: 'String' },
+    })
+
+    expect(result.imageId).toEqual('String')
+    expect(result.url).toEqual('String')
+  })
+
+  scenario('updates a imageGallery', async (scenario: StandardScenario) => {
+    const original = (await imageGallery({
+      id: scenario.imageGallery.one.id,
+    })) as ImageGallery
+    const result = await updateImageGallery({
+      id: original.id,
+      input: { imageId: 'String2' },
+    })
+
+    expect(result.imageId).toEqual('String2')
+  })
+
+  scenario('deletes a imageGallery', async (scenario: StandardScenario) => {
+    const original = (await deleteImageGallery({
+      id: scenario.imageGallery.one.id,
+    })) as ImageGallery
+    const result = await imageGallery({ id: original.id })
+
+    expect(result).toEqual(null)
+  })
+})

--- a/api/src/services/imageGalleries/imageGalleries.test.ts
+++ b/api/src/services/imageGalleries/imageGalleries.test.ts
@@ -31,27 +31,6 @@ describe('imageGalleries', () => {
     }
   )
 
-  scenario('creates a imageGallery', async () => {
-    const result = await createImageGallery({
-      input: { imageId: 'String', url: 'String' },
-    })
-
-    expect(result.imageId).toEqual('String')
-    expect(result.url).toEqual('String')
-  })
-
-  scenario('updates a imageGallery', async (scenario: StandardScenario) => {
-    const original = (await imageGallery({
-      id: scenario.imageGallery.one.id,
-    })) as ImageGallery
-    const result = await updateImageGallery({
-      id: original.id,
-      input: { imageId: 'String2' },
-    })
-
-    expect(result.imageId).toEqual('String2')
-  })
-
   scenario('deletes a imageGallery', async (scenario: StandardScenario) => {
     const original = (await deleteImageGallery({
       id: scenario.imageGallery.one.id,

--- a/api/src/services/imageGalleries/imageGalleries.ts
+++ b/api/src/services/imageGalleries/imageGalleries.ts
@@ -48,4 +48,7 @@ export const ImageGallery: ImageGalleryRelationResolvers = {
       .findUnique({ where: { id: root?.id } })
       .ImageGalleryOnPost()
   },
+  images: (_obj, { root }) => {
+    return db.imageGallery.findUnique({ where: { id: root?.id } }).images()
+  },
 }

--- a/api/src/services/imageGalleries/imageGalleries.ts
+++ b/api/src/services/imageGalleries/imageGalleries.ts
@@ -1,0 +1,51 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ImageGalleryRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const imageGalleries: QueryResolvers['imageGalleries'] = () => {
+  return db.imageGallery.findMany()
+}
+
+export const imageGallery: QueryResolvers['imageGallery'] = ({ id }) => {
+  return db.imageGallery.findUnique({
+    where: { id },
+  })
+}
+
+export const createImageGallery: MutationResolvers['createImageGallery'] = ({
+  input,
+}) => {
+  return db.imageGallery.create({
+    data: input,
+  })
+}
+
+export const updateImageGallery: MutationResolvers['updateImageGallery'] = ({
+  id,
+  input,
+}) => {
+  return db.imageGallery.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deleteImageGallery: MutationResolvers['deleteImageGallery'] = ({
+  id,
+}) => {
+  return db.imageGallery.delete({
+    where: { id },
+  })
+}
+
+export const ImageGallery: ImageGalleryRelationResolvers = {
+  ImageGalleryOnPost: (_obj, { root }) => {
+    return db.imageGallery
+      .findUnique({ where: { id: root?.id } })
+      .ImageGalleryOnPost()
+  },
+}

--- a/api/src/services/imageGalleryImages/imageGalleryImages.scenarios.ts
+++ b/api/src/services/imageGalleryImages/imageGalleryImages.scenarios.ts
@@ -1,0 +1,18 @@
+import type { Prisma, ImageGalleryImage } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.ImageGalleryImageCreateArgs>({
+  imageGalleryImage: {
+    one: {
+      data: { imageId: 'String', url: 'String', imageGallery: { create: {} } },
+    },
+    two: {
+      data: { imageId: 'String', url: 'String', imageGallery: { create: {} } },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<
+  ImageGalleryImage,
+  'imageGalleryImage'
+>

--- a/api/src/services/imageGalleryImages/imageGalleryImages.test.ts
+++ b/api/src/services/imageGalleryImages/imageGalleryImages.test.ts
@@ -1,0 +1,86 @@
+import type { ImageGalleryImage } from '@prisma/client'
+
+import {
+  imageGalleryImages,
+  imageGalleryImage,
+  createImageGalleryImage,
+  updateImageGalleryImage,
+  deleteImageGalleryImage,
+} from './imageGalleryImages'
+import type { StandardScenario } from './imageGalleryImages.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('imageGalleryImages', () => {
+  scenario(
+    'returns all imageGalleryImages',
+    async (scenario: StandardScenario) => {
+      const result = await imageGalleryImages()
+
+      expect(result.length).toEqual(
+        Object.keys(scenario.imageGalleryImage).length
+      )
+    }
+  )
+
+  scenario(
+    'returns a single imageGalleryImage',
+    async (scenario: StandardScenario) => {
+      const result = await imageGalleryImage({
+        id: scenario.imageGalleryImage.one.id,
+      })
+
+      expect(result).toEqual(scenario.imageGalleryImage.one)
+    }
+  )
+
+  scenario(
+    'creates a imageGalleryImage',
+    async (scenario: StandardScenario) => {
+      const result = await createImageGalleryImage({
+        input: {
+          imageId: 'String',
+          url: 'String',
+          imageGalleryId: scenario.imageGalleryImage.two.imageGalleryId,
+        },
+      })
+
+      expect(result.imageId).toEqual('String')
+      expect(result.url).toEqual('String')
+      expect(result.imageGalleryId).toEqual(
+        scenario.imageGalleryImage.two.imageGalleryId
+      )
+    }
+  )
+
+  scenario(
+    'updates a imageGalleryImage',
+    async (scenario: StandardScenario) => {
+      const original = (await imageGalleryImage({
+        id: scenario.imageGalleryImage.one.id,
+      })) as ImageGalleryImage
+      const result = await updateImageGalleryImage({
+        id: original.id,
+        input: { imageId: 'String2' },
+      })
+
+      expect(result.imageId).toEqual('String2')
+    }
+  )
+
+  scenario(
+    'deletes a imageGalleryImage',
+    async (scenario: StandardScenario) => {
+      const original = (await deleteImageGalleryImage({
+        id: scenario.imageGalleryImage.one.id,
+      })) as ImageGalleryImage
+      const result = await imageGalleryImage({ id: original.id })
+
+      expect(result).toEqual(null)
+    }
+  )
+})

--- a/api/src/services/imageGalleryImages/imageGalleryImages.ts
+++ b/api/src/services/imageGalleryImages/imageGalleryImages.ts
@@ -1,0 +1,49 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ImageGalleryImageRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const imageGalleryImages: QueryResolvers['imageGalleryImages'] = () => {
+  return db.imageGalleryImage.findMany()
+}
+
+export const imageGalleryImage: QueryResolvers['imageGalleryImage'] = ({
+  id,
+}) => {
+  return db.imageGalleryImage.findUnique({
+    where: { id },
+  })
+}
+
+export const createImageGalleryImage: MutationResolvers['createImageGalleryImage'] =
+  ({ input }) => {
+    return db.imageGalleryImage.create({
+      data: input,
+    })
+  }
+
+export const updateImageGalleryImage: MutationResolvers['updateImageGalleryImage'] =
+  ({ id, input }) => {
+    return db.imageGalleryImage.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteImageGalleryImage: MutationResolvers['deleteImageGalleryImage'] =
+  ({ id }) => {
+    return db.imageGalleryImage.delete({
+      where: { id },
+    })
+  }
+
+export const ImageGalleryImage: ImageGalleryImageRelationResolvers = {
+  imageGallery: (_obj, { root }) => {
+    return db.imageGalleryImage
+      .findUnique({ where: { id: root?.id } })
+      .imageGallery()
+  },
+}

--- a/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.scenarios.ts
+++ b/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.scenarios.ts
@@ -5,13 +5,13 @@ export const standard = defineScenario<Prisma.ImageGalleryOnPostCreateArgs>({
   imageGalleryOnPost: {
     one: {
       data: {
-        imageGallery: { create: { imageId: 'String', url: 'String' } },
+        imageGallery: { create: {} },
         post: {
           create: {
             title: 'String',
             user: {
               create: {
-                email: 'String9778770',
+                email: 'String3497095',
                 hashedPassword: 'String',
                 salt: 'String',
               },
@@ -22,13 +22,13 @@ export const standard = defineScenario<Prisma.ImageGalleryOnPostCreateArgs>({
     },
     two: {
       data: {
-        imageGallery: { create: { imageId: 'String', url: 'String' } },
+        imageGallery: { create: {} },
         post: {
           create: {
             title: 'String',
             user: {
               create: {
-                email: 'String3196586',
+                email: 'String2678795',
                 hashedPassword: 'String',
                 salt: 'String',
               },

--- a/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.scenarios.ts
+++ b/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.scenarios.ts
@@ -1,0 +1,46 @@
+import type { Prisma, ImageGalleryOnPost } from '@prisma/client'
+import type { ScenarioData } from '@redwoodjs/testing/api'
+
+export const standard = defineScenario<Prisma.ImageGalleryOnPostCreateArgs>({
+  imageGalleryOnPost: {
+    one: {
+      data: {
+        imageGallery: { create: { imageId: 'String', url: 'String' } },
+        post: {
+          create: {
+            title: 'String',
+            user: {
+              create: {
+                email: 'String9778770',
+                hashedPassword: 'String',
+                salt: 'String',
+              },
+            },
+          },
+        },
+      },
+    },
+    two: {
+      data: {
+        imageGallery: { create: { imageId: 'String', url: 'String' } },
+        post: {
+          create: {
+            title: 'String',
+            user: {
+              create: {
+                email: 'String3196586',
+                hashedPassword: 'String',
+                salt: 'String',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+export type StandardScenario = ScenarioData<
+  ImageGalleryOnPost,
+  'imageGalleryOnPost'
+>

--- a/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.test.ts
+++ b/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.test.ts
@@ -1,0 +1,88 @@
+import type { ImageGalleryOnPost } from '@prisma/client'
+
+import {
+  imageGalleryOnPosts,
+  imageGalleryOnPost,
+  createImageGalleryOnPost,
+  updateImageGalleryOnPost,
+  deleteImageGalleryOnPost,
+} from './imageGalleryOnPosts'
+import type { StandardScenario } from './imageGalleryOnPosts.scenarios'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float.
+//           Please refer to the RedwoodJS Testing Docs:
+//       https://redwoodjs.com/docs/testing#testing-services
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('imageGalleryOnPosts', () => {
+  scenario(
+    'returns all imageGalleryOnPosts',
+    async (scenario: StandardScenario) => {
+      const result = await imageGalleryOnPosts()
+
+      expect(result.length).toEqual(
+        Object.keys(scenario.imageGalleryOnPost).length
+      )
+    }
+  )
+
+  scenario(
+    'returns a single imageGalleryOnPost',
+    async (scenario: StandardScenario) => {
+      const result = await imageGalleryOnPost({
+        id: scenario.imageGalleryOnPost.one.id,
+      })
+
+      expect(result).toEqual(scenario.imageGalleryOnPost.one)
+    }
+  )
+
+  scenario(
+    'creates a imageGalleryOnPost',
+    async (scenario: StandardScenario) => {
+      const result = await createImageGalleryOnPost({
+        input: {
+          imageGalleryId: scenario.imageGalleryOnPost.two.imageGalleryId,
+          postId: scenario.imageGalleryOnPost.two.postId,
+        },
+      })
+
+      expect(result.imageGalleryId).toEqual(
+        scenario.imageGalleryOnPost.two.imageGalleryId
+      )
+      expect(result.postId).toEqual(scenario.imageGalleryOnPost.two.postId)
+    }
+  )
+
+  scenario(
+    'updates a imageGalleryOnPost',
+    async (scenario: StandardScenario) => {
+      const original = (await imageGalleryOnPost({
+        id: scenario.imageGalleryOnPost.one.id,
+      })) as ImageGalleryOnPost
+      const result = await updateImageGalleryOnPost({
+        id: original.id,
+        input: {
+          imageGalleryId: scenario.imageGalleryOnPost.two.imageGalleryId,
+        },
+      })
+
+      expect(result.imageGalleryId).toEqual(
+        scenario.imageGalleryOnPost.two.imageGalleryId
+      )
+    }
+  )
+
+  scenario(
+    'deletes a imageGalleryOnPost',
+    async (scenario: StandardScenario) => {
+      const original = (await deleteImageGalleryOnPost({
+        id: scenario.imageGalleryOnPost.one.id,
+      })) as ImageGalleryOnPost
+      const result = await imageGalleryOnPost({ id: original.id })
+
+      expect(result).toEqual(null)
+    }
+  )
+})

--- a/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.ts
+++ b/api/src/services/imageGalleryOnPosts/imageGalleryOnPosts.ts
@@ -1,0 +1,53 @@
+import type {
+  QueryResolvers,
+  MutationResolvers,
+  ImageGalleryOnPostRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const imageGalleryOnPosts: QueryResolvers['imageGalleryOnPosts'] =
+  () => {
+    return db.imageGalleryOnPost.findMany()
+  }
+
+export const imageGalleryOnPost: QueryResolvers['imageGalleryOnPost'] = ({
+  id,
+}) => {
+  return db.imageGalleryOnPost.findUnique({
+    where: { id },
+  })
+}
+
+export const createImageGalleryOnPost: MutationResolvers['createImageGalleryOnPost'] =
+  ({ input }) => {
+    return db.imageGalleryOnPost.create({
+      data: input,
+    })
+  }
+
+export const updateImageGalleryOnPost: MutationResolvers['updateImageGalleryOnPost'] =
+  ({ id, input }) => {
+    return db.imageGalleryOnPost.update({
+      data: input,
+      where: { id },
+    })
+  }
+
+export const deleteImageGalleryOnPost: MutationResolvers['deleteImageGalleryOnPost'] =
+  ({ id }) => {
+    return db.imageGalleryOnPost.delete({
+      where: { id },
+    })
+  }
+
+export const ImageGalleryOnPost: ImageGalleryOnPostRelationResolvers = {
+  imageGallery: (_obj, { root }) => {
+    return db.imageGalleryOnPost
+      .findUnique({ where: { id: root?.id } })
+      .imageGallery()
+  },
+  post: (_obj, { root }) => {
+    return db.imageGalleryOnPost.findUnique({ where: { id: root?.id } }).post()
+  },
+}

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -38,4 +38,10 @@ export const Post: PostRelationResolvers = {
     }
     return null
   },
+  imageGalleries: (_obj, { root }) => {
+    if (root.type === 'ARTICLE') {
+      return db.imageGalleryOnPost.findMany({ where: { postId: root?.id } })
+    }
+    return []
+  },
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -94,6 +94,30 @@ export default async () => {
         body: 'This is my first post',
         published: true,
         userId: 1,
+        imageGalleries: {
+          create: [
+            {
+              imageGallery: {
+                create: {
+                  name: 'First Gallery',
+                  description: 'This is the first gallery',
+                  images: {
+                    create: [
+                      {
+                        imageId: 'b1b9a0c0-9f0a-11eb-8dcd-0242ac130003',
+                        url: 'https://picsum.photos/seed/1/200/300',
+                      },
+                      {
+                        imageId: 'b1b9a0c0-9f0a-11eb-8dcd-0242ac130004',
+                        url: 'https://picsum.photos/seed/2/200/300',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
       },
       {
         title: 'Second Post',

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -28,12 +28,6 @@ const Routes = () => {
       <Private unauthenticated="login">
         <Set wrap={AdminDashboardLayout}>
           <Route path="/admin" page={() => <Redirect to={adminRedirect} />} name="admin" />
-          <Set wrap={ScaffoldLayout} title="Posts" titleTo="posts" buttonLabel="New Post" buttonTo="newPost">
-            <Route path="/admin/posts/new" page={PostNewPostPage} name="newPost" />
-            <Route path="/admin/posts/{id:Int}/edit" page={PostEditPostPage} name="editPost" />
-            <Route path="/admin/posts/{id:Int}" page={PostPostPage} name="post" />
-            <Route path="/admin/posts" page={PostPostsPage} name="posts" />
-          </Set>
           <Set wrap={ScaffoldLayout} title="My Posts" titleTo="myPosts" buttonLabel="New Post" buttonTo="newPost">
             <Route path="/admin/posts/new" page={PostNewPostPage} name="newPost" />
             <Route path="/admin/posts/{id:Int}/edit" page={PostEditPostPage} name="editPost" />

--- a/web/src/components/Article/components/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle.tsx
@@ -124,6 +124,18 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
           <div>
             <RenderBody body={article.body} />
           </div>
+          {/* this is how you can render images from an image gallery: */}
+          {article.imageGalleries.map((imageGalleryOnPost) => {
+            return imageGalleryOnPost.imageGallery.images.map((image) => {
+              return (
+                <img
+                  key={image.id}
+                  src={image.url}
+                  alt={imageGalleryOnPost.imageGallery.name}
+                />
+              )
+            })
+          })}
         </>
       )}
     </>

--- a/web/src/components/Article/components/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle.tsx
@@ -124,18 +124,6 @@ const ArticleArticle = ({ article, displayType, date }: Props) => {
           <div>
             <RenderBody body={article.body} />
           </div>
-          {/* this is how you can render images from an image gallery: */}
-          {article.imageGalleries.map((imageGalleryOnPost) => {
-            return imageGalleryOnPost.imageGallery.images.map((image) => {
-              return (
-                <img
-                  key={image.id}
-                  src={image.url}
-                  alt={imageGalleryOnPost.imageGallery.name}
-                />
-              )
-            })
-          })}
         </>
       )}
     </>

--- a/web/src/components/ArticleCell/ArticleCell.tsx
+++ b/web/src/components/ArticleCell/ArticleCell.tsx
@@ -46,6 +46,18 @@ export const QUERY = gql`
           up
         }
       }
+      imageGalleries {
+        id
+        imageGallery {
+          name
+          description
+          images {
+            id
+            url
+            imageId
+          }
+        }
+      }
     }
   }
 `

--- a/web/src/components/Post/MyPostsCell/MyPostsCell.tsx
+++ b/web/src/components/Post/MyPostsCell/MyPostsCell.tsx
@@ -6,7 +6,7 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import Posts from 'src/components/Post/Posts'
 
 export const QUERY = gql`
-  query FindPosts {
+  query FindMyPosts {
     posts: adminPosts {
       id
       title

--- a/web/src/components/RenderBody/RenderBody.test.tsx
+++ b/web/src/components/RenderBody/RenderBody.test.tsx
@@ -8,7 +8,9 @@ import RenderBody from './RenderBody'
 describe('RenderBody', () => {
   it('renders successfully', () => {
     expect(() => {
-      render(<RenderBody />)
+      const body = `# Hello, world! \n\n This is a test.`
+
+      render(<RenderBody body={body} />)
     }).not.toThrow()
   })
 })


### PR DESCRIPTION
This PR adds several models, sdls and services to the application with the following relations:

Every Post now has an array of ImageGalleryOnPost

Every ImageGalleryOnPost has an ImageGallery

Every ImageGallery has multiple images

I haven't yet created a frontend / form that will allow us to add new image galleries, but I have added an image gallery to a post in the seeder. My question to you @naomi-eliasar: Can you style the / an image gallery component that will display the images per gallery for a post? If you need more images, you can add some extra images / image galleries in [seed.ts](https://github.com/drikusroor/ohayo-goededagu/pull/107/files#diff-dc31c45b12f01153e351ab68c73d2d8b069b987d4595344f79b9af5e3116f924). 

In [ArticleArticle.tsx](https://github.com/drikusroor/ohayo-goededagu/pull/107/files#diff-a75258074168e9a399f45879318976bcf5c0c40ecf901a856e9ad250cf3b86ac) you can see how to get the image gallery from a post.