### PR TITLE
Add google drive url as video option #113

### DIFF
--- a/web/src/components/Article/components/helpers/extract-video-id.ts
+++ b/web/src/components/Article/components/helpers/extract-video-id.ts
@@ -22,6 +22,14 @@ function extractVideoID(url: string): string | null {
     result = regex.exec(url)
   }
 
+  // Google Drive's URL
+  if (!result) {
+    regex =
+      /^https?:\/\/(?:www\.)?drive.google.com\/file\/d\/([a-zA-Z0-9_-]{33})/
+    result = regex.exec(url)
+    console.log('result', result)
+  }
+
   return result && result[1] ? result[1] : null
 }
 

--- a/web/src/components/Video/Video.tsx
+++ b/web/src/components/Video/Video.tsx
@@ -6,9 +6,15 @@ const Video = ({ embedUrl = '' }) => {
   const formattedEmbedUrl = useMemo(() => {
     if (!embedUrl) return null
 
+    const isDriveUrl = embedUrl.includes('drive.google')
+
     const videoId = extractVideoID(embedUrl)
     if (!videoId) return null
-    return `https://www.youtube.com/embed/${videoId}`
+    if (isDriveUrl) {
+      return `https://drive.google.com/file/d/${videoId}/preview`
+    } else {
+      return `https://www.youtube.com/embed/${videoId}`
+    }
   }, [embedUrl])
 
   if (!formattedEmbedUrl) return null
@@ -18,7 +24,7 @@ const Video = ({ embedUrl = '' }) => {
       <iframe
         src={formattedEmbedUrl}
         className="h-full w-full"
-        title="YouTube video player"
+        title="Video player"
         frameBorder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowFullScreen


### PR DESCRIPTION
Up until now it was only possible to use a youtube url to embed a video.
This PR aims to add the google drive embed src & share url as an option to share a video.