### PR TITLE
Feat/158 styling improvements

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -38,13 +38,13 @@ const Routes = () => {
             <Route path="/admin/posts/{id:Int}" page={PostPostPage} name="post" />
             <Route path="/admin/posts" page={PostPostsPage} name="posts" />
           </Set>
-          <Set wrap={ScaffoldLayout} title="ImageGalleries" titleTo="imageGalleries" buttonLabel="New ImageGallery" buttonTo="newImageGallery">
+          <Set wrap={ScaffoldLayout} title="ImageGalleries" titleTo="imageGalleries">
             <Route path="/admin/image-galleries/new" page={ImageGalleryNewImageGalleryPage} name="newImageGallery" />
             <Route path="/admin/image-galleries/{id:Int}/edit" page={ImageGalleryEditImageGalleryPage} name="editImageGallery" />
             <Route path="/admin/image-galleries/{id:Int}" page={ImageGalleryImageGalleryPage} name="imageGallery" />
             <Route path="/admin/image-galleries" page={ImageGalleryImageGalleriesPage} name="imageGalleries" />
           </Set>
-          <Set wrap={ScaffoldLayout} title="Comments" titleTo="comments" buttonLabel="New Comment" buttonTo="newComment">
+          <Set wrap={ScaffoldLayout} title="Comments" titleTo="comments">
             <Route path="/admin/comments/new" page={CommentNewCommentPage} name="newComment" />
             <Route path="/admin/comments/{id:Int}/edit" page={CommentEditCommentPage} name="editComment" />
             <Route path="/admin/comments/{id:Int}" page={CommentCommentPage} name="comment" />

--- a/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
@@ -15,6 +15,7 @@ import ArticleTypeIcon, {
   EPostType,
 } from '../../../ArticleTypeIcon/ArticleTypeIcon'
 import Avatar from '../../../Avatar/Avatar'
+import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
@@ -49,50 +50,7 @@ const ArticleArticle = ({ article, displayType }: Props) => {
           className="rounded bg-gray-600 bg-cover bg-center bg-no-repeat bg-blend-multiply"
         >
           <div className="mx-auto max-w-screen-xl px-4 py-20 md:py-24 lg:py-56">
-            <div className="flex flex-row items-center justify-center gap-2 pb-2">
-              <div>
-                <ArticleTypeIcon type={article.type as EPostType} />
-              </div>
-
-              <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
-                {article.title}
-              </h1>
-            </div>
-            <RenderBody
-              body={article.body}
-              className="!prose-invert mx-auto mb-8  line-clamp-3 text-center"
-            />
-            <div className="flex flex-row items-center justify-center gap-12">
-              <div className="flex flex-row items-center gap-2">
-                <Avatar
-                  src={article.user?.profile?.avatar}
-                  alt={article.user.name}
-                  name={article.user.name || article.user.email}
-                  userId={article.user?.id}
-                />
-                <div className="flex flex-col items-start">
-                  <span className="text-sm text-slate-300" title={authorName}>
-                    {authorName}
-                  </span>
-                  <DisplayDatetime
-                    className="text-sm text-slate-300"
-                    datetime={article.createdAt}
-                  />
-                </div>
-              </div>
-              {article?.comments?.length > 0 && (
-                <ArticleCommentCountBadge count={article.comments.length} />
-              )}
-              <Link
-                to={routes.article({ id: article.id })}
-                className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
-              >
-                <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
-                  <span className="hidden sm:inline-block">Lees verder</span>
-                  <BsArrowRightCircle />
-                </Button>
-              </Link>
-            </div>
+            <PreviewLayout article={article} authorName={authorName} />
           </div>
         </section>
       )}

--- a/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
@@ -1,20 +1,7 @@
-import { BsArrowRightCircle } from 'react-icons/bs'
 import type { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
-
-import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
-import Button from 'src/components/Button/Button'
-import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
-import LocationPin from 'src/components/LocationPin/LocationPin'
-import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
-import RenderBody from 'src/components/RenderBody/RenderBody'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
-import ArticleTypeIcon, {
-  EPostType,
-} from '../../../ArticleTypeIcon/ArticleTypeIcon'
-import Avatar from '../../../Avatar/Avatar'
 import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
@@ -25,19 +12,6 @@ interface Props {
 
 const ArticleArticle = ({ article, displayType }: Props) => {
   const { coverImage } = article
-
-  const { imageGalleries = [] } = article
-
-  const galleries = imageGalleries.reduce((acc, galleryOnPost) => {
-    const { imageGallery } = galleryOnPost
-    if (imageGallery) {
-      return [...acc, imageGallery]
-    }
-    return acc
-  }, [])
-
-  const authorName =
-    article?.user?.profile?.name || article?.user?.name || 'Anonymous'
 
   return (
     <>

--- a/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
@@ -15,6 +15,7 @@ import ArticleTypeIcon, {
   EPostType,
 } from '../../../ArticleTypeIcon/ArticleTypeIcon'
 import Avatar from '../../../Avatar/Avatar'
+import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
@@ -50,67 +51,13 @@ const ArticleArticle = ({ article, displayType }: Props) => {
           className="rounded bg-gray-600 bg-cover bg-center bg-no-repeat bg-blend-multiply"
         >
           <div className="mx-auto max-w-screen-xl px-4 py-20 md:py-24 lg:py-56">
-            <PreviewLayout article={article} authorName={authorName} />
+            <PreviewLayout article={article} />
           </div>
         </section>
       )}
 
       {displayType === EPostDisplayType.FULL && (
-        <>
-          <section
-            style={{
-              backgroundImage: coverImage?.url
-                ? `url(${coverImage.url})`
-                : `url(/images/logo-full.png)`,
-            }}
-            className="rounded bg-gray-400 bg-cover bg-center bg-no-repeat bg-blend-multiply"
-          >
-            <div className="flex aspect-video max-w-screen-xl flex-col justify-end px-4">
-              <div className="flex flex-row items-center justify-start gap-2">
-                <div>
-                  <ArticleTypeIcon type={article.type as EPostType} />
-                </div>
-                <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase leading-none tracking-tight text-white drop-shadow-xl md:gap-4 md:text-5xl lg:text-6xl">
-                  {article.title}
-                </h1>
-              </div>
-              <div className="flex flex-row items-center gap-2 pb-2">
-                <Link
-                  to={
-                    article.user?.id
-                      ? routes.viewProfile({ id: article.user?.id })
-                      : '#'
-                  }
-                  className="text-sm text-slate-200 hover:underline"
-                  title={`View ${authorName}'s profile`}
-                >
-                  {authorName}
-                </Link>
-                <DisplayDatetime
-                  datetime={article.createdAt}
-                  showDate={true}
-                  className="text-sm text-slate-200"
-                />
-                <LocationPin
-                  location={article.location}
-                  className="text-white"
-                />
-              </div>
-            </div>
-          </section>
-          <div>
-            <RenderBody body={article.body} />
-          </div>
-          {galleries &&
-            galleries.map((gallery, index) => (
-              <PhotoGrid
-                key={index}
-                images={gallery.images}
-                preview={false}
-                className="block h-full w-full"
-              />
-            ))}
-        </>
+        <FullLayout article={article} />
       )}
     </>
   )

--- a/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
+++ b/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
@@ -27,7 +27,7 @@ const ArticleChotto = ({ article, displayType }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <PreviewLayout article={article} authorName={authorName} />
+        <PreviewLayout article={article} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
+++ b/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
@@ -12,6 +12,7 @@ import { EPostDisplayType } from 'src/types/post-display-type.enum'
 import ArticleTypeIcon, {
   EPostType,
 } from '../../../ArticleTypeIcon/ArticleTypeIcon'
+import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
@@ -26,37 +27,7 @@ const ArticleChotto = ({ article, displayType }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <>
-          <header className="mb-3">
-            <div className="mt-4 flex flex-row items-center gap-2 pl-1">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              <h2
-                className="text-xl font-semibold text-slate-700 md:text-2xl"
-                title={article.title}
-              >
-                <Link to={routes.article({ id: article.id })}>
-                  {article.title}
-                </Link>
-              </h2>
-            </div>
-          </header>
-          <div className="lg:mx-14">
-            <div>
-              <div className="justmt-2 line-clamp-5">
-                <RenderBody body={article.body} />
-              </div>
-              <div className="flex items-center justify-between pt-4">
-                <AvatarTimestamp article={article} />
-                {article?.comments?.length > 0 && (
-                  <ArticleCommentCountBadge
-                    count={article.comments.length}
-                    variant="dark"
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        </>
+        <PreviewLayout article={article} authorName={authorName} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
+++ b/web/src/components/Article/components/ArticleChotto/ArticleChotto.tsx
@@ -1,29 +1,16 @@
 import type { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
-
-import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
-import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimestamp'
-import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
-import LocationPin from 'src/components/LocationPin/LocationPin'
-import RenderBody from 'src/components/RenderBody/RenderBody'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
-import ArticleTypeIcon, {
-  EPostType,
-} from '../../../ArticleTypeIcon/ArticleTypeIcon'
+import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
   displayType: EPostDisplayType
-  date?: string
 }
 
 const ArticleChotto = ({ article, displayType }: Props) => {
-  const authorName =
-    article?.user?.profile?.name || article?.user?.name || 'Anonymous'
-
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
@@ -31,35 +18,7 @@ const ArticleChotto = ({ article, displayType }: Props) => {
       )}
 
       {displayType === EPostDisplayType.FULL && (
-        <>
-          <header className="flex flex-col gap-1">
-            <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase leading-none tracking-tight md:gap-4">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              {article.title}
-            </h1>
-
-            <div className="flex flex-row items-center gap-2">
-              <Link
-                to={
-                  article.user?.id
-                    ? routes.viewProfile({ id: article.user?.id })
-                    : '#'
-                }
-                className="text-sm text-slate-500 hover:underline"
-                title={`View ${authorName}'s profile`}
-              >
-                {authorName}
-              </Link>
-              <DisplayDatetime
-                datetime={article.createdAt}
-                className="text-sm text-slate-500"
-                showDate={true}
-              />
-              <LocationPin location={article.location} />
-            </div>
-          </header>
-          <RenderBody body={article.body} />
-        </>
+        <FullLayout article={article} />
       )}
     </>
   )

--- a/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
+++ b/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
@@ -1,28 +1,16 @@
 import type { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
-
-import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
-import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimestamp'
-import RenderBody from 'src/components/RenderBody/RenderBody'
-import Preview from 'src/components/Upload/Preview/Preview'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
-import ArticleTypeIcon, {
-  EPostType,
-} from '../../../ArticleTypeIcon/ArticleTypeIcon'
+import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
   displayType: EPostDisplayType
-  date?: string
 }
 
-const ArticleHaiku = ({ article, displayType, date }: Props) => {
-  const authorName =
-    article.user.profile?.name || article.user.name || 'Anonymous'
-
+const ArticleHaiku = ({ article, displayType }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
@@ -30,30 +18,7 @@ const ArticleHaiku = ({ article, displayType, date }: Props) => {
       )}
 
       {displayType === EPostDisplayType.FULL && (
-        <>
-          <header className="flex flex-col gap-1">
-            <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase leading-none tracking-tight md:gap-4">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              {article.title}
-            </h1>
-
-            <div className="flex flex-row items-center gap-2">
-              <Link
-                to={
-                  article.user?.id
-                    ? routes.viewProfile({ id: article.user?.id })
-                    : '#'
-                }
-                className="text-sm text-slate-500 hover:underline"
-                title={`View ${authorName}'s profile`}
-              >
-                {authorName}
-              </Link>
-              <span className="text-sm text-slate-500"> | {date}</span>
-            </div>
-          </header>
-          <RenderBody body={article.body} />
-        </>
+        <FullLayout article={article} />
       )}
     </>
   )

--- a/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
+++ b/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
@@ -5,11 +5,13 @@ import { Link, routes } from '@redwoodjs/router'
 import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
 import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimestamp'
 import RenderBody from 'src/components/RenderBody/RenderBody'
+import Preview from 'src/components/Upload/Preview/Preview'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
 import ArticleTypeIcon, {
   EPostType,
 } from '../../../ArticleTypeIcon/ArticleTypeIcon'
+import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
@@ -24,37 +26,7 @@ const ArticleHaiku = ({ article, displayType, date }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <>
-          <header className="mb-3">
-            <div className="mt-4 flex flex-row items-center gap-2 pl-1">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              <h2
-                className="text-xl font-semibold text-slate-700 md:text-2xl"
-                title={article.title}
-              >
-                <Link to={routes.article({ id: article.id })}>
-                  {article.title}
-                </Link>
-              </h2>
-            </div>
-          </header>
-          <div className="lg:mx-14">
-            <div>
-              <div className="justmt-2 line-clamp-5">
-                <RenderBody body={article.body} />
-              </div>
-              <div className="flex items-center justify-between pt-4">
-                <AvatarTimestamp article={article} />
-                {article?.comments?.length > 0 && (
-                  <ArticleCommentCountBadge
-                    count={article.comments.length}
-                    variant="dark"
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        </>
+        <PreviewLayout article={article} authorName={authorName} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
+++ b/web/src/components/Article/components/ArticleHaiku/ArticleHaiku.tsx
@@ -26,7 +26,7 @@ const ArticleHaiku = ({ article, displayType, date }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <PreviewLayout article={article} authorName={authorName} />
+        <PreviewLayout article={article} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
+++ b/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
@@ -31,12 +31,14 @@ const ArticlePhotoGallery = ({ article, displayType }: Props) => {
       {displayType === EPostDisplayType.PREVIEW && (
         <>
           <div className="relative">
-            <PhotoGrid
-              key={galleries[0]}
-              images={galleries[0].images}
-              preview={true}
-              className="block h-full w-full"
-            />
+            {galleries[0] && (
+              <PhotoGrid
+                key={galleries[0]}
+                images={galleries[0].images}
+                preview={true}
+                className="block h-full w-full"
+              />
+            )}
             <div className="font-3xl lg:min-h-48 min-h-20 md:min-h-24 absolute bottom-0 mx-auto flex h-full w-full flex-col justify-center rounded-md bg-gray-600 bg-opacity-50 px-4 text-center text-white text-opacity-100">
               <PreviewLayout article={article} />
             </div>

--- a/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
+++ b/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
@@ -13,6 +13,8 @@ import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
 import { formatCreatedDate } from 'src/lib/formatters'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
+import PreviewLayout from '../PreviewLayout/PreviewLayout'
+
 interface Props {
   article: Post
   displayType: EPostDisplayType
@@ -49,6 +51,10 @@ const ArticlePhotoGallery = ({ article, displayType, date }: Props) => {
               className="block h-full w-full"
             />
             <div className="font-3xl lg:min-h-48 min-h-20 md:min-h-24 absolute bottom-0 mx-auto flex h-full w-full flex-col justify-center rounded-md bg-gray-600 bg-opacity-50 px-4 text-center text-white text-opacity-100">
+              <PreviewLayout article={article} authorName={authorName} />
+            </div>
+
+            {/* <div className="font-3xl lg:min-h-48 min-h-20 md:min-h-24 absolute bottom-0 mx-auto flex h-full w-full flex-col justify-center rounded-md bg-gray-600 bg-opacity-50 px-4 text-center text-white text-opacity-100">
               <div className="flex flex-row items-center justify-center gap-2 pb-2">
                 <div>
                   <ArticleTypeIcon type={article.type as EPostType} />
@@ -88,7 +94,7 @@ const ArticlePhotoGallery = ({ article, displayType, date }: Props) => {
                   </Button>
                 </Link>
               </div>
-            </div>
+            </div> */}
           </div>
         </>
       )}

--- a/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
+++ b/web/src/components/Article/components/ArticlePhotoGallery/ArticlePhotoGallery.tsx
@@ -1,30 +1,17 @@
-import { BsArrowRightCircle } from 'react-icons/bs'
 import { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
-
-import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
-import ArticleTypeIcon, {
-  EPostType,
-} from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
-import Avatar from 'src/components/Avatar/Avatar'
-import Button from 'src/components/Button/Button'
 import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
-import { formatCreatedDate } from 'src/lib/formatters'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
+import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
   displayType: EPostDisplayType
-  date?: string
 }
 
-const ArticlePhotoGallery = ({ article, displayType, date }: Props) => {
-  const authorName =
-    article.user?.profile?.name || article.user?.name || 'Anonymous'
-
+const ArticlePhotoGallery = ({ article, displayType }: Props) => {
   const { imageGalleries = [] } = article
 
   const galleries = imageGalleries.reduce((acc, galleryOnPost) => {
@@ -51,85 +38,13 @@ const ArticlePhotoGallery = ({ article, displayType, date }: Props) => {
               className="block h-full w-full"
             />
             <div className="font-3xl lg:min-h-48 min-h-20 md:min-h-24 absolute bottom-0 mx-auto flex h-full w-full flex-col justify-center rounded-md bg-gray-600 bg-opacity-50 px-4 text-center text-white text-opacity-100">
-              <PreviewLayout article={article} authorName={authorName} />
+              <PreviewLayout article={article} />
             </div>
-
-            {/* <div className="font-3xl lg:min-h-48 min-h-20 md:min-h-24 absolute bottom-0 mx-auto flex h-full w-full flex-col justify-center rounded-md bg-gray-600 bg-opacity-50 px-4 text-center text-white text-opacity-100">
-              <div className="flex flex-row items-center justify-center gap-2 pb-2">
-                <div>
-                  <ArticleTypeIcon type={article.type as EPostType} />
-                </div>
-
-                <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
-                  {article.title}
-                </h1>
-              </div>
-              <div className="flex flex-row items-center justify-center gap-12">
-                <div className="flex flex-row items-center gap-2">
-                  <Avatar
-                    src={article.user?.profile?.avatar}
-                    alt={article.user.name}
-                    name={article.user.name || article.user.email}
-                    userId={article.user?.id}
-                  />
-                  <div className="flex flex-col items-start">
-                    <span className="text-sm text-slate-300" title={authorName}>
-                      {authorName}
-                    </span>
-                    {formatCreatedDate(article.createdAt)}
-                  </div>
-                </div>
-                {article?.comments?.length > 0 && (
-                  <ArticleCommentCountBadge count={article.comments.length} />
-                )}
-                <Link
-                  to={routes.article({ id: article.id })}
-                  className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
-                >
-                  <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
-                    <span className="hidden sm:inline-block">
-                      Zie alle foto&apos;s
-                    </span>
-                    <BsArrowRightCircle />
-                  </Button>
-                </Link>
-              </div>
-            </div> */}
           </div>
         </>
       )}
       {displayType === EPostDisplayType.FULL && (
-        <>
-          <header className="mb-4 flex flex-col gap-1">
-            <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase tracking-tight md:gap-4">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              {article.title}
-            </h1>
-            <div className="flex flex-row items-center gap-2">
-              <Link
-                to={
-                  article.user?.id
-                    ? routes.viewProfile({ id: article.user?.id })
-                    : '#'
-                }
-                className="text-sm text-slate-500 hover:underline"
-                title={`View ${authorName}'s profile`}
-              >
-                {authorName}
-              </Link>
-              <span className="text-sm text-slate-500"> | {date}</span>
-            </div>
-          </header>
-          <div> {article.body} </div>
-          {galleries.map((gallery, index) => (
-            <PhotoGrid
-              key={index}
-              images={gallery.images}
-              preview={false}
-              className="block h-full w-full"
-            />
-          ))}
-        </>
+        <FullLayout article={article} />
       )}
     </>
   )

--- a/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
+++ b/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
@@ -15,6 +15,8 @@ import RenderBody from 'src/components/RenderBody/RenderBody'
 import Video from 'src/components/Video/Video'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
+import PreviewLayout from '../PreviewLayout/PreviewLayout'
+
 interface Props {
   article: Post
   displayType: EPostDisplayType
@@ -30,44 +32,7 @@ const ArticleVideo = ({ article, displayType }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <>
-          <header className="mb-3">
-            <div className="mt-4 flex flex-row items-center gap-2 pl-1">
-              <ArticleTypeIcon type={EPostType.VIDEO} />
-              <h2
-                className="text-xl font-semibold text-slate-700 md:text-2xl"
-                title={article.title}
-              >
-                <Link to={routes.article({ id: article.id })}>
-                  {article.title}
-                </Link>
-              </h2>
-            </div>
-          </header>
-
-          <Video embedUrl={article?.videoPost?.videoUrl} />
-
-          <div className="flex flex-row items-center justify-between pt-4">
-            <AvatarTimestamp article={article} />
-            <div className="flex items-center gap-6">
-              {article?.comments?.length > 0 && (
-                <ArticleCommentCountBadge
-                  count={article.comments.length}
-                  variant="dark"
-                />
-              )}
-              {article.body && (
-                <Button
-                  className="flex items-center gap-2 px-4 py-3 text-xs"
-                  onClick={() => navigate(routes.article({ id: article.id }))}
-                >
-                  <span className="hidden sm:inline-block">Lees verder</span>
-                  <BsArrowRightCircle />
-                </Button>
-              )}
-            </div>
-          </div>
-        </>
+        <PreviewLayout article={article} authorName={authorName} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
+++ b/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
@@ -32,7 +32,7 @@ const ArticleVideo = ({ article, displayType }: Props) => {
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
-        <PreviewLayout article={article} authorName={authorName} />
+        <PreviewLayout article={article} />
       )}
 
       {displayType === EPostDisplayType.FULL && (

--- a/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
+++ b/web/src/components/Article/components/ArticleVideo/ArticleVideo.tsx
@@ -1,32 +1,16 @@
-import { BsArrowRightCircle } from 'react-icons/bs'
 import { Post } from 'types/graphql'
 
-import { Link, navigate, routes } from '@redwoodjs/router'
-
-import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
-import ArticleTypeIcon, {
-  EPostType,
-} from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
-import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimestamp'
-import Button from 'src/components/Button/Button'
-import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
-import LocationPin from 'src/components/LocationPin/LocationPin'
-import RenderBody from 'src/components/RenderBody/RenderBody'
-import Video from 'src/components/Video/Video'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
+import FullLayout from '../FullLayout/FullLayout'
 import PreviewLayout from '../PreviewLayout/PreviewLayout'
 
 interface Props {
   article: Post
   displayType: EPostDisplayType
-  date?: string
 }
 
 const ArticleVideo = ({ article, displayType }: Props) => {
-  const authorName =
-    article.user?.profile?.name || article.user?.name || 'Anonymous'
-
   if (!article?.videoPost?.videoUrl) return null
 
   return (
@@ -36,26 +20,7 @@ const ArticleVideo = ({ article, displayType }: Props) => {
       )}
 
       {displayType === EPostDisplayType.FULL && (
-        <>
-          <header className="flex flex-col gap-1">
-            <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase tracking-tight md:gap-4">
-              <ArticleTypeIcon type={article.type as EPostType} />
-              {article.title}
-            </h1>
-
-            <div className="flex flex-row items-center gap-2">
-              <span className="text-sm text-slate-500">{authorName}</span>
-              <DisplayDatetime
-                datetime={article.createdAt}
-                showDate={true}
-                className="text-sm text-slate-500"
-              />
-              <LocationPin location={article.location} className="text-white" />
-            </div>
-          </header>
-          <Video embedUrl={article?.videoPost?.videoUrl} />
-          <RenderBody body={article.body} />
-        </>
+        <FullLayout article={article} />
       )}
     </>
   )

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -6,6 +6,7 @@ import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
 import LocationPin from 'src/components/LocationPin/LocationPin'
 import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
 import RenderBody from 'src/components/RenderBody/RenderBody'
+import Video from 'src/components/Video/Video'
 
 import ArticleTypeIcon, {
   EPostType,
@@ -102,14 +103,19 @@ const FullLayout = ({ article }: Props) => {
                 showDate={true}
                 className="text-sm text-slate-500"
               />
+              <LocationPin location={article.location} />
             </div>
           </header>
         </>
       )}
 
       <div>
+        {article.videoPost != null && (
+          <Video embedUrl={article?.videoPost?.videoUrl} />
+        )}
         <RenderBody body={article.body} />
       </div>
+
       {galleries &&
         galleries.map((gallery, index) => (
           <PhotoGrid

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -1,12 +1,13 @@
 import type { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, navigate, routes } from '@redwoodjs/router'
 
 import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
 import LocationPin from 'src/components/LocationPin/LocationPin'
 import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
 import RenderBody from 'src/components/RenderBody/RenderBody'
 import Video from 'src/components/Video/Video'
+import Person from 'src/pages/AboutPage/Person'
 
 import ArticleTypeIcon, {
   EPostType,
@@ -125,6 +126,28 @@ const FullLayout = ({ article }: Props) => {
             className="block h-full w-full"
           />
         ))}
+
+      <div
+        onClick={() =>
+          article.user.id
+            ? navigate(routes.viewProfile({ id: article.user.id }))
+            : '#'
+        }
+        onKeyDown={() =>
+          article.user.id
+            ? navigate(routes.viewProfile({ id: article.user.id }))
+            : '#'
+        }
+        tabIndex={0}
+        role="button"
+        key={article.user.id}
+        className="pt-10"
+      >
+        <Person
+          profile={article?.user?.profile}
+          style="cursor-pointer hover:border-black"
+        />
+      </div>
     </>
   )
 }

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -1,0 +1,126 @@
+import type { Post } from 'types/graphql'
+
+import { Link, routes } from '@redwoodjs/router'
+
+import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
+import LocationPin from 'src/components/LocationPin/LocationPin'
+import PhotoGrid from 'src/components/PhotoGrid/PhotoGrid'
+import RenderBody from 'src/components/RenderBody/RenderBody'
+
+import ArticleTypeIcon, {
+  EPostType,
+} from '../../../ArticleTypeIcon/ArticleTypeIcon'
+
+interface Props {
+  article: Post
+}
+
+const FullLayout = ({ article }: Props) => {
+  const authorName =
+    article?.user?.profile?.name || article?.user?.name || 'Anonymous'
+
+  const hasCoverImage = article.coverImage != null
+
+  const { imageGalleries = [] } = article
+  const galleries = imageGalleries.reduce((acc, galleryOnPost) => {
+    const { imageGallery } = galleryOnPost
+    if (imageGallery) {
+      return [...acc, imageGallery]
+    }
+    return acc
+  }, [])
+
+  return (
+    <>
+      {hasCoverImage && (
+        <>
+          <section
+            style={{
+              backgroundImage: article.coverImage?.url
+                ? `url(${article.coverImage.url})`
+                : `url(/images/logo-full.png)`,
+            }}
+            className="rounded bg-gray-400 bg-cover bg-center bg-no-repeat bg-blend-multiply"
+          >
+            <div className="flex aspect-video max-w-screen-xl flex-col justify-end px-4">
+              <div className="flex flex-row items-center justify-start gap-2">
+                <div>
+                  <ArticleTypeIcon type={article.type as EPostType} />
+                </div>
+                <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase leading-none tracking-tight text-white drop-shadow-xl md:gap-4 md:text-5xl lg:text-6xl">
+                  {article.title}
+                </h1>
+              </div>
+              <div className="flex flex-row items-center gap-2 pb-2">
+                <Link
+                  to={
+                    article.user?.id
+                      ? routes.viewProfile({ id: article.user?.id })
+                      : '#'
+                  }
+                  className="text-sm text-slate-200 hover:underline"
+                  title={`View ${authorName}'s profile`}
+                >
+                  {authorName}
+                </Link>
+                <DisplayDatetime
+                  datetime={article.createdAt}
+                  showDate={true}
+                  className="text-sm text-slate-200"
+                />
+                <LocationPin
+                  location={article.location}
+                  className="text-white"
+                />
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+
+      {!hasCoverImage && (
+        <>
+          <header className="mb-4 flex flex-col gap-1">
+            <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase tracking-tight md:gap-4">
+              <ArticleTypeIcon type={article.type as EPostType} />
+              {article.title}
+            </h1>
+            <div className="flex flex-row items-center gap-2">
+              <Link
+                to={
+                  article.user?.id
+                    ? routes.viewProfile({ id: article.user?.id })
+                    : '#'
+                }
+                className="text-sm text-slate-500 hover:underline"
+                title={`View ${authorName}'s profile`}
+              >
+                {authorName}
+              </Link>
+              <DisplayDatetime
+                datetime={article.createdAt}
+                showDate={true}
+                className="text-sm text-slate-500"
+              />
+            </div>
+          </header>
+        </>
+      )}
+
+      <div>
+        <RenderBody body={article.body} />
+      </div>
+      {galleries &&
+        galleries.map((gallery, index) => (
+          <PhotoGrid
+            key={index}
+            images={gallery.images}
+            preview={false}
+            className="block h-full w-full"
+          />
+        ))}
+    </>
+  )
+}
+
+export default FullLayout

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -8,10 +8,10 @@ import ArticleTypeIcon, {
   EPostType,
 } from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
 import Avatar from 'src/components/Avatar/Avatar'
+import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimestamp'
 import Button from 'src/components/Button/Button'
 import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
 import RenderBody from 'src/components/RenderBody/RenderBody'
-import { formatCreatedDate } from 'src/lib/formatters'
 
 interface Props {
   article: Post
@@ -19,61 +19,104 @@ interface Props {
 }
 
 const PreviewLayout = ({ article, authorName }: Props) => {
+  const hasImage =
+    article.type === EPostType.ARTICLE ||
+    article.type === EPostType.PHOTO_GALLERY
+
+  console.log('article.type', article.type)
+  console.log('hasImage', hasImage)
+
   return (
     <>
-      <div className="flex flex-row items-center justify-center gap-2 pb-4">
-        <div>
-          <ArticleTypeIcon type={article.type as EPostType} />
-        </div>
-
-        <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
-          {article.title}
-        </h1>
-      </div>
-      {article.type === EPostType.ARTICLE && (
-        <RenderBody
-          body={article.body}
-          className="!prose-invert mx-auto mb-8  line-clamp-3 text-center"
-        />
-      )}
-      <div className="flex flex-row items-center justify-center gap-12">
-        <div className="flex flex-row items-center gap-2">
-          <Avatar
-            src={article.user?.profile?.avatar}
-            alt={article.user.name}
-            name={article.user.name || article.user.email}
-            userId={article.user?.id}
-          />
-          <div className="flex flex-col items-start">
-            <span className="text-sm text-slate-300" title={authorName}>
-              {authorName}
-            </span>
-            <DisplayDatetime
-              className="text-sm text-slate-300"
-              datetime={article.createdAt}
-            />
+      {hasImage && (
+        <>
+          <div className="flex flex-row items-center justify-center gap-2 pb-4">
+            <div>
+              <ArticleTypeIcon type={article.type as EPostType} />
+            </div>
+            <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
+              {article.title}
+            </h1>
           </div>
-        </div>
-        {article?.comments?.length > 0 && (
-          <ArticleCommentCountBadge count={article.comments.length} />
-        )}
-        <Link
-          to={routes.article({ id: article.id })}
-          className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
-        >
-          <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
-            {article.type === EPostType.PHOTO_GALLERY && (
-              <span className="hidden sm:inline-block">
-                Zie alle foto&apos;s
-              </span>
+          {article.type === EPostType.ARTICLE && (
+            <RenderBody
+              body={article.body}
+              className="!prose-invert mx-auto mb-8  line-clamp-3 text-center"
+            />
+          )}
+          <div className="flex flex-row items-center justify-center gap-12">
+            <div className="flex flex-row items-center gap-2">
+              <Avatar
+                src={article.user?.profile?.avatar}
+                alt={article.user.name}
+                name={article.user.name || article.user.email}
+                userId={article.user?.id}
+              />
+              <div className="flex flex-col items-start">
+                <span className="text-sm text-slate-300" title={authorName}>
+                  {authorName}
+                </span>
+                <DisplayDatetime
+                  className="text-sm text-slate-300"
+                  datetime={article.createdAt}
+                />
+              </div>
+            </div>
+            {article?.comments?.length > 0 && (
+              <ArticleCommentCountBadge count={article.comments.length} />
             )}
-            {article.type === EPostType.ARTICLE && (
-              <span className="hidden sm:inline-block">Lees verder</span>
-            )}
-            <BsArrowRightCircle />
-          </Button>
-        </Link>
-      </div>
+            <Link
+              to={routes.article({ id: article.id })}
+              className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
+            >
+              <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
+                {article.type === EPostType.PHOTO_GALLERY && (
+                  <span className="hidden sm:inline-block">
+                    Zie alle foto&apos;s
+                  </span>
+                )}
+                {article.type === EPostType.ARTICLE && (
+                  <span className="hidden sm:inline-block">Lees verder</span>
+                )}
+                <BsArrowRightCircle />
+              </Button>
+            </Link>
+          </div>
+        </>
+      )}
+      {!hasImage && (
+        <>
+          <header className="mb-3">
+            <div className="mt-4 flex flex-row items-center gap-2 pl-1">
+              <ArticleTypeIcon type={article.type as EPostType} />
+              <h2
+                className="text-xl font-semibold text-slate-700 md:text-2xl"
+                title={article.title}
+              >
+                <Link to={routes.article({ id: article.id })}>
+                  {article.title}
+                </Link>
+              </h2>
+            </div>
+          </header>
+          <div className="lg:mx-14">
+            <div>
+              <div className="justmt-2 line-clamp-5">
+                <RenderBody body={article.body} />
+              </div>
+              <div className="flex items-center justify-between pt-4">
+                <AvatarTimestamp article={article} />
+                {article?.comments?.length > 0 && (
+                  <ArticleCommentCountBadge
+                    count={article.comments.length}
+                    variant="dark"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </>
   )
 }

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -1,7 +1,7 @@
 import { BsArrowRightCircle } from 'react-icons/bs'
 import { Post } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, navigate, routes } from '@redwoodjs/router'
 
 import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
 import ArticleTypeIcon, {
@@ -12,6 +12,7 @@ import AvatarTimestamp from 'src/components/Avatar/AvatarTimestamp/AvatarTimesta
 import Button from 'src/components/Button/Button'
 import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
 import RenderBody from 'src/components/RenderBody/RenderBody'
+import Video from 'src/components/Video/Video'
 
 interface Props {
   article: Post
@@ -22,9 +23,6 @@ const PreviewLayout = ({ article, authorName }: Props) => {
   const hasImage =
     article.type === EPostType.ARTICLE ||
     article.type === EPostType.PHOTO_GALLERY
-
-  console.log('article.type', article.type)
-  console.log('hasImage', hasImage)
 
   return (
     <>
@@ -99,18 +97,37 @@ const PreviewLayout = ({ article, authorName }: Props) => {
               </h2>
             </div>
           </header>
-          <div className="lg:mx-14">
-            <div>
+
+          {article.type === EPostType.VIDEO && (
+            <Video embedUrl={article?.videoPost?.videoUrl} />
+          )}
+
+          <div
+            className={article.type != EPostType.VIDEO ? 'lg:mx-16' : 'lg:mx-0'}
+          >
+            {article.type != EPostType.VIDEO && (
               <div className="justmt-2 line-clamp-5">
                 <RenderBody body={article.body} />
               </div>
-              <div className="flex items-center justify-between pt-4">
-                <AvatarTimestamp article={article} />
+            )}
+
+            <div className="flex items-center justify-between pt-4">
+              <AvatarTimestamp article={article} />
+              <div className="flex items-center gap-6">
                 {article?.comments?.length > 0 && (
                   <ArticleCommentCountBadge
                     count={article.comments.length}
                     variant="dark"
                   />
+                )}
+                {article.type === EPostType.VIDEO && article.body && (
+                  <Button
+                    className="flex items-center gap-2 px-4 py-3 text-xs"
+                    onClick={() => navigate(routes.article({ id: article.id }))}
+                  >
+                    <span className="hidden sm:inline-block">Lees verder</span>
+                    <BsArrowRightCircle />
+                  </Button>
                 )}
               </div>
             </div>

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -16,10 +16,12 @@ import Video from 'src/components/Video/Video'
 
 interface Props {
   article: Post
-  authorName: string
 }
 
-const PreviewLayout = ({ article, authorName }: Props) => {
+const PreviewLayout = ({ article }: Props) => {
+  const authorName =
+    article?.user?.profile?.name || article?.user?.name || 'Anonymous'
+
   const hasImage =
     article.type === EPostType.ARTICLE ||
     article.type === EPostType.PHOTO_GALLERY

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -1,0 +1,81 @@
+import { BsArrowRightCircle } from 'react-icons/bs'
+import { Post } from 'types/graphql'
+
+import { Link, routes } from '@redwoodjs/router'
+
+import ArticleCommentCountBadge from 'src/components/ArticleCommentCountBadge/ArticleCommentCountBadge'
+import ArticleTypeIcon, {
+  EPostType,
+} from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
+import Avatar from 'src/components/Avatar/Avatar'
+import Button from 'src/components/Button/Button'
+import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
+import RenderBody from 'src/components/RenderBody/RenderBody'
+import { formatCreatedDate } from 'src/lib/formatters'
+
+interface Props {
+  article: Post
+  authorName: string
+}
+
+const PreviewLayout = ({ article, authorName }: Props) => {
+  return (
+    <>
+      <div className="flex flex-row items-center justify-center gap-2 pb-4">
+        <div>
+          <ArticleTypeIcon type={article.type as EPostType} />
+        </div>
+
+        <h1 className="flex flex-wrap items-center justify-center text-3xl font-extrabold leading-none tracking-tight text-white md:text-5xl lg:text-6xl">
+          {article.title}
+        </h1>
+      </div>
+      {article.type === EPostType.ARTICLE && (
+        <RenderBody
+          body={article.body}
+          className="!prose-invert mx-auto mb-8  line-clamp-3 text-center"
+        />
+      )}
+      <div className="flex flex-row items-center justify-center gap-12">
+        <div className="flex flex-row items-center gap-2">
+          <Avatar
+            src={article.user?.profile?.avatar}
+            alt={article.user.name}
+            name={article.user.name || article.user.email}
+            userId={article.user?.id}
+          />
+          <div className="flex flex-col items-start">
+            <span className="text-sm text-slate-300" title={authorName}>
+              {authorName}
+            </span>
+            <DisplayDatetime
+              className="text-sm text-slate-300"
+              datetime={article.createdAt}
+            />
+          </div>
+        </div>
+        {article?.comments?.length > 0 && (
+          <ArticleCommentCountBadge count={article.comments.length} />
+        )}
+        <Link
+          to={routes.article({ id: article.id })}
+          className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
+        >
+          <Button className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs">
+            {article.type === EPostType.PHOTO_GALLERY && (
+              <span className="hidden sm:inline-block">
+                Zie alle foto&apos;s
+              </span>
+            )}
+            {article.type === EPostType.ARTICLE && (
+              <span className="hidden sm:inline-block">Lees verder</span>
+            )}
+            <BsArrowRightCircle />
+          </Button>
+        </Link>
+      </div>
+    </>
+  )
+}
+
+export default PreviewLayout

--- a/web/src/components/ArticleCell/ArticleCell.tsx
+++ b/web/src/components/ArticleCell/ArticleCell.tsx
@@ -25,6 +25,10 @@ export const QUERY = gql`
         name
         profile {
           name
+          japaneseName
+          avatar
+          bio
+          id
         }
       }
       comments {

--- a/web/src/components/Comment/Comments/Comments.tsx
+++ b/web/src/components/Comment/Comments/Comments.tsx
@@ -3,13 +3,12 @@ import type {
   FindComments,
 } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
+import { navigate, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/Comment/CommentsCell'
-import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
-import { checkboxInputTag, truncate } from 'src/lib/formatters'
+import DashboardTable from 'src/components/Table/DashboardTable'
 
 const DELETE_COMMENT_MUTATION = gql`
   mutation DeleteCommentMutation($id: Int!) {
@@ -40,72 +39,27 @@ const CommentsList = ({ comments }: FindComments) => {
     }
   }
 
+  const headers = [
+    'Id',
+    'Body',
+    'Created at',
+    'User id',
+    'Post id',
+    'Parent id',
+    'Deleted',
+    'Show',
+    'Edit',
+    'Delete',
+  ]
+
   return (
-    <div className="rw-segment rw-table-wrapper-responsive">
-      <table className="rw-table">
-        <thead>
-          <tr>
-            <th>Id</th>
-            <th>Body</th>
-            <th>Created at</th>
-            <th>User id</th>
-            <th>Post id</th>
-            <th>Parent id</th>
-            <th>Deleted</th>
-            <th>&nbsp;</th>
-          </tr>
-        </thead>
-        <tbody>
-          {comments.map((comment) => (
-            <tr key={comment.id}>
-              <td>{truncate(comment.id)}</td>
-              <td>{truncate(comment.body)}</td>
-              <td>
-                <DisplayDatetime datetime={comment.createdAt} showDate />
-              </td>
-              <td>{truncate(comment.userId)}</td>
-              <td>
-                <Link
-                  to={routes.article({ id: comment.postId })}
-                  title={'Show post ' + comment.postId + ' detail'}
-                  className="flex flex-row items-center gap-2 text-blue-500 underline hover:text-blue-700"
-                >
-                  {truncate(comment.postId)}
-                </Link>
-              </td>
-              <td>{truncate(comment.parentId)}</td>
-              <td>{checkboxInputTag(comment.deleted)}</td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Link
-                    to={routes.comment({ id: comment.id })}
-                    title={'Show comment ' + comment.id + ' detail'}
-                    className="rw-button rw-button-small"
-                  >
-                    Show
-                  </Link>
-                  <Link
-                    to={routes.editComment({ id: comment.id })}
-                    title={'Edit comment ' + comment.id}
-                    className="rw-button rw-button-small rw-button-blue"
-                  >
-                    Edit
-                  </Link>
-                  <button
-                    type="button"
-                    title={'Delete comment ' + comment.id}
-                    className="rw-button rw-button-small rw-button-red"
-                    onClick={() => onDeleteClick(comment.id)}
-                  >
-                    Delete
-                  </button>
-                </nav>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DashboardTable
+      headers={headers}
+      data={comments}
+      onShow={(comment) => navigate(routes.comment({ id: comment.id }))}
+      onEdit={(comment) => navigate(routes.comment({ id: comment.id }))}
+      onDelete={(comment) => onDeleteClick(comment.id)}
+    />
   )
 }
 

--- a/web/src/components/ImageGallery/ImageGalleries/ImageGalleries.tsx
+++ b/web/src/components/ImageGallery/ImageGalleries/ImageGalleries.tsx
@@ -3,12 +3,12 @@ import type {
   FindImageGalleries,
 } from 'types/graphql'
 
-import { Link, routes } from '@redwoodjs/router'
+import { navigate, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY } from 'src/components/ImageGallery/ImageGalleriesCell'
-import { timeTag, truncate } from 'src/lib/formatters'
+import DashboardTable from 'src/components/Table/DashboardTable'
 
 const DELETE_IMAGE_GALLERY_MUTATION = gql`
   mutation DeleteImageGalleryMutation($id: Int!) {
@@ -39,56 +39,20 @@ const ImageGalleriesList = ({ imageGalleries }: FindImageGalleries) => {
     }
   }
 
+  const headers = ['Id', 'Created at', 'Name', 'Description']
+
   return (
-    <div className="rw-segment rw-table-wrapper-responsive">
-      <table className="rw-table">
-        <thead>
-          <tr>
-            <th>Id</th>
-            <th>Created at</th>
-            <th>Name</th>
-            <th>Description</th>
-            <th>&nbsp;</th>
-          </tr>
-        </thead>
-        <tbody>
-          {imageGalleries.map((imageGallery) => (
-            <tr key={imageGallery.id}>
-              <td>{truncate(imageGallery.id)}</td>
-              <td>{timeTag(imageGallery.createdAt)}</td>
-              <td>{truncate(imageGallery.name)}</td>
-              <td>{truncate(imageGallery.description)}</td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Link
-                    to={routes.imageGallery({ id: imageGallery.id })}
-                    title={'Show imageGallery ' + imageGallery.id + ' detail'}
-                    className="rw-button rw-button-small"
-                  >
-                    Show
-                  </Link>
-                  <Link
-                    to={routes.editImageGallery({ id: imageGallery.id })}
-                    title={'Edit imageGallery ' + imageGallery.id}
-                    className="rw-button rw-button-small rw-button-blue"
-                  >
-                    Edit
-                  </Link>
-                  <button
-                    type="button"
-                    title={'Delete imageGallery ' + imageGallery.id}
-                    className="rw-button rw-button-small rw-button-red"
-                    onClick={() => onDeleteClick(imageGallery.id)}
-                  >
-                    Delete
-                  </button>
-                </nav>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DashboardTable
+      headers={headers}
+      data={imageGalleries}
+      onShow={(imageGallery) =>
+        navigate(routes.imageGallery({ id: imageGallery.id }))
+      }
+      onEdit={(imageGallery) =>
+        navigate(routes.editImageGallery({ id: imageGallery.id }))
+      }
+      onDelete={(imageGallery) => onDeleteClick(imageGallery.id)}
+    />
   )
 }
 

--- a/web/src/components/ImageGallery/ImageGalleries/ImageGalleries.tsx
+++ b/web/src/components/ImageGallery/ImageGalleries/ImageGalleries.tsx
@@ -39,7 +39,15 @@ const ImageGalleriesList = ({ imageGalleries }: FindImageGalleries) => {
     }
   }
 
-  const headers = ['Id', 'Created at', 'Name', 'Description']
+  const headers = [
+    'Id',
+    'Created at',
+    'Name',
+    'Description',
+    'Show',
+    'Edit',
+    'Delete',
+  ]
 
   return (
     <DashboardTable

--- a/web/src/components/PhotoGrid/PhotoGrid.tsx
+++ b/web/src/components/PhotoGrid/PhotoGrid.tsx
@@ -31,9 +31,9 @@ const PhotoGrid = ({ className, images = [], preview }: IPhotoGridProps) => {
   return (
     <>
       <div className={classNames('rounded-md bg-gray-200 p-2', className)}>
-        <ul className="grid grid-cols-2 flex-wrap gap-4 md:flex">
-          {preview &&
-            previewGallery.map((photo) => {
+        {preview && (
+          <ul className="grid grid-cols-2 flex-wrap gap-4">
+            {previewGallery.map((photo) => {
               return (
                 <li
                   className="relative grow basis-auto last:flex-initial lg:h-[300px]"
@@ -48,50 +48,51 @@ const PhotoGrid = ({ className, images = [], preview }: IPhotoGridProps) => {
                 </li>
               )
             })}
-          {!preview &&
-            images &&
-            images.map((photo, index) => {
+          </ul>
+        )}
+        {!preview && images && (
+          <ul className="flex flex-wrap gap-4 md:grid md:grid-cols-2">
+            {images.map((photo, index) => {
               return (
-                <>
-                  <li
-                    className="relative h-[300px] grow basis-auto last:flex-initial"
-                    key={photo.imageId}
-                  >
-                    <img
-                      className="h-full w-full cursor-pointer rounded-md object-cover align-middle"
-                      key={index}
-                      src={photo.url}
-                      alt={photo.imageId}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => {
-                        setModalInfo({
-                          url: photo.url,
-                          id: photo.id,
-                          imageId: photo.imageId,
-                          title: photo?.name ? photo?.name : '',
-                          description: photo?.description
-                            ? photo?.description
-                            : '',
-                        })
-                      }}
-                      onKeyDown={() => {
-                        setModalInfo({
-                          url: photo.url,
-                          id: photo.id,
-                          imageId: photo.imageId,
-                          title: photo?.name ? photo?.name : '',
-                          description: photo?.description
-                            ? photo?.description
-                            : '',
-                        })
-                      }}
-                    />
-                  </li>
-                </>
+                <li
+                  className="relative h-[300px] grow basis-auto last:flex-initial"
+                  key={photo.imageId}
+                >
+                  <img
+                    className="h-full w-full cursor-pointer rounded-md object-cover align-middle"
+                    key={index}
+                    src={photo.url}
+                    alt={photo.imageId}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                      setModalInfo({
+                        url: photo.url,
+                        id: photo.id,
+                        imageId: photo.imageId,
+                        title: photo?.name ? photo?.name : '',
+                        description: photo?.description
+                          ? photo?.description
+                          : '',
+                      })
+                    }}
+                    onKeyDown={() => {
+                      setModalInfo({
+                        url: photo.url,
+                        id: photo.id,
+                        imageId: photo.imageId,
+                        title: photo?.name ? photo?.name : '',
+                        description: photo?.description
+                          ? photo?.description
+                          : '',
+                      })
+                    }}
+                  />
+                </li>
               )
             })}
-        </ul>
+          </ul>
+        )}
       </div>
       <ImageModal info={modalInfo} />
     </>

--- a/web/src/components/Post/Posts/Posts.tsx
+++ b/web/src/components/Post/Posts/Posts.tsx
@@ -1,24 +1,11 @@
-import {
-  BsFillPencilFill,
-  BsFillTrash3Fill,
-  BsPencilSquare,
-  BsSearch,
-  BsSendFill,
-} from 'react-icons/bs'
 import type { DeletePostMutationVariables, FindPosts } from 'types/graphql'
 
 import { routes, navigate } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 import { toast } from '@redwoodjs/web/toast'
 
-import { useAuth } from 'src/auth'
-import ArticleTypeIcon, {
-  EPostType,
-} from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
-import Button from 'src/components/Button/Button'
 import { QUERY } from 'src/components/Post/PostsCell'
-import RenderBody from 'src/components/RenderBody/RenderBody'
-import { timeTag, truncate } from 'src/lib/formatters'
+import DashboardTable from 'src/components/Table/DashboardTable'
 
 const DELETE_POST_MUTATION = gql`
   mutation DeletePostMutation($id: Int!) {
@@ -29,8 +16,6 @@ const DELETE_POST_MUTATION = gql`
 `
 
 const PostsList = ({ posts }: FindPosts) => {
-  const { currentUser } = useAuth()
-
   const [deletePost] = useMutation(DELETE_POST_MUTATION, {
     onCompleted: () => {
       toast.success('Post deleted')
@@ -59,87 +44,29 @@ const PostsList = ({ posts }: FindPosts) => {
     }
   }
 
+  const headers = [
+    'Id',
+    'Title',
+    'Body',
+    'Type',
+    'Published',
+    'Author',
+    'Created at',
+    '',
+    '',
+    '',
+  ]
+
   return (
-    <div className="rw-segment rw-table-wrapper-responsive">
-      <table className="rw-table">
-        <thead>
-          <tr>
-            <th>Id</th>
-            <th>Title</th>
-            <th>Body</th>
-            <th>Type</th>
-            <th>Published</th>
-            <th>Author</th>
-            <th>Created at</th>
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
-            <th>&nbsp;</th>
-          </tr>
-        </thead>
-        <tbody>
-          {posts.map((post) => (
-            <tr key={post.id}>
-              <td>{truncate(post.id)}</td>
-              <td>{truncate(post.title)}</td>
-              <td>
-                <RenderBody body={truncate(post.body)} />
-              </td>
-              <td>
-                <ArticleTypeIcon type={post.type as EPostType} />
-              </td>
-              <td>{post.published ? <BsSendFill /> : <BsPencilSquare />}</td>
-              <td>{post?.user?.name}</td>
-              <td>{timeTag(post.createdAt)}</td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Button
-                    title={'Show post' + post.id}
-                    onClick={() => onNavigatePost(post)}
-                    className="rw-button flex items-center gap-2 text-base transition-colors sm:text-sm"
-                    color="rw-gray"
-                    icon={BsSearch}
-                    variant="outlined"
-                  >
-                    <BsSearch />
-                    <span className="hidden lg:inline-block">Show</span>
-                  </Button>
-                </nav>
-              </td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Button
-                    title={'Edit post' + post.id}
-                    onClick={() => onNavigateEditPost(post)}
-                    className="rw-button rw-button-blue flex items-center gap-2 text-base transition-colors sm:text-sm"
-                    color="cobalt-blue"
-                    variant="outlined"
-                  >
-                    <BsFillPencilFill />
-                    <span className="hidden lg:inline-block">Edit</span>
-                  </Button>
-                </nav>
-              </td>
-              <td>
-                <nav className="rw-table-actions">
-                  {post?.user?.name === currentUser?.name && (
-                    <Button
-                      title={'Delete post ' + post.id}
-                      onClick={() => onDeleteClick(post.id)}
-                      className="rw-button rw-button-red flex items-center gap-2 text-base transition-colors sm:text-sm"
-                      color="monza-red"
-                      variant="outlined"
-                    >
-                      <BsFillTrash3Fill />
-                      <span className="hidden lg:inline-block">Delete</span>
-                    </Button>
-                  )}
-                </nav>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <>
+      <DashboardTable
+        headers={headers}
+        data={posts}
+        onShow={(post) => onNavigatePost(post)}
+        onEdit={(post) => onNavigateEditPost(post)}
+        onDelete={(postId) => onDeleteClick(postId)}
+      />
+    </>
   )
 }
 

--- a/web/src/components/Post/Posts/Posts.tsx
+++ b/web/src/components/Post/Posts/Posts.tsx
@@ -52,9 +52,6 @@ const PostsList = ({ posts }: FindPosts) => {
     'Published',
     'Author',
     'Created at',
-    '',
-    '',
-    '',
   ]
 
   return (

--- a/web/src/components/Post/Posts/Posts.tsx
+++ b/web/src/components/Post/Posts/Posts.tsx
@@ -52,6 +52,9 @@ const PostsList = ({ posts }: FindPosts) => {
     'Published',
     'Author',
     'Created at',
+    'Show',
+    'Edit',
+    'Delete',
   ]
 
   return (

--- a/web/src/components/Reisgenootschap/Reisgenootschap.tsx
+++ b/web/src/components/Reisgenootschap/Reisgenootschap.tsx
@@ -1,3 +1,4 @@
+import { Link, navigate, routes } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
 import Person from 'src/pages/AboutPage/Person'
@@ -23,13 +24,22 @@ const Reisgenootschap = ({ reisgenootschap = [] }: IReisgenootschapProps) => {
   return (
     <div className="grid gap-4 p-3 md:grid-cols-2 md:p-10">
       {reisgenootschap.map(({ id, profile }) => (
-        <Person
+        <div
+          onClick={() => (id ? navigate(routes.viewProfile({ id: id })) : '#')}
+          onKeyDown={() =>
+            id ? navigate(routes.viewProfile({ id: id })) : '#'
+          }
+          tabIndex={0}
+          role="button"
           key={id}
-          name={profile?.name}
-          quote={profile?.japaneseName}
-          story={profile?.bio}
-          imgSrc={profile?.avatar}
-        />
+        >
+          <Person
+            key={id}
+            id={id}
+            profile={profile}
+            style="cursor-pointer hover:border-black"
+          />
+        </div>
       ))}
     </div>
   )

--- a/web/src/components/Table/DashboardTable.tsx
+++ b/web/src/components/Table/DashboardTable.tsx
@@ -1,0 +1,105 @@
+import {
+  BsFillPencilFill,
+  BsFillTrash3Fill,
+  BsPencilSquare,
+  BsSearch,
+  BsSendFill,
+} from 'react-icons/bs'
+
+import { useAuth } from 'src/auth'
+import ArticleTypeIcon, {
+  EPostType,
+} from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
+import Button from 'src/components/Button/Button'
+import RenderBody from 'src/components/RenderBody/RenderBody'
+import { timeTag, truncate } from 'src/lib/formatters'
+
+interface Props {
+  headers: Array<string>
+  data: object
+  onDelete?: (value) => void
+  onEdit?: (value) => void
+  onShow?: (value) => void
+}
+
+const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
+  const { currentUser } = useAuth()
+
+  return (
+    <div className="rw-segment rw-table-wrapper-responsive">
+      <table className="rw-table">
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header}> {header} </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((post) => (
+            <tr key={post.id}>
+              <td>{truncate(post.id)}</td>
+              <td>{truncate(post.title)}</td>
+              <td>
+                <RenderBody body={truncate(post.body)} />
+              </td>
+              <td>
+                <ArticleTypeIcon type={post.type as EPostType} />
+              </td>
+              <td>{post.published ? <BsSendFill /> : <BsPencilSquare />}</td>
+              <td>{post?.user?.name}</td>
+              <td>{timeTag(post.createdAt)}</td>
+              <td>
+                <nav className="rw-table-actions">
+                  <Button
+                    title={'Show post' + post.id}
+                    onClick={() => onShow(post)}
+                    className="rw-button flex items-center gap-2 text-base transition-colors sm:text-sm"
+                    color="rw-gray"
+                    icon={BsSearch}
+                    variant="outlined"
+                  >
+                    <BsSearch />
+                    <span className="hidden lg:inline-block">Show</span>
+                  </Button>
+                </nav>
+              </td>
+              <td>
+                <nav className="rw-table-actions">
+                  <Button
+                    title={'Edit post' + post.id}
+                    onClick={() => onEdit(post)}
+                    className="rw-button rw-button-blue flex items-center gap-2 text-base transition-colors sm:text-sm"
+                    color="cobalt-blue"
+                    variant="outlined"
+                  >
+                    <BsFillPencilFill />
+                    <span className="hidden lg:inline-block">Edit</span>
+                  </Button>
+                </nav>
+              </td>
+              <td>
+                <nav className="rw-table-actions">
+                  {post?.user?.name === currentUser?.name && (
+                    <Button
+                      title={'Delete post ' + post.id}
+                      onClick={() => onDelete(post.id)}
+                      className="rw-button rw-button-red flex items-center gap-2 text-base transition-colors sm:text-sm"
+                      color="monza-red"
+                      variant="outlined"
+                    >
+                      <BsFillTrash3Fill />
+                      <span className="hidden lg:inline-block">Delete</span>
+                    </Button>
+                  )}
+                </nav>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default DashboardTable

--- a/web/src/components/Table/DashboardTable.tsx
+++ b/web/src/components/Table/DashboardTable.tsx
@@ -6,13 +6,17 @@ import {
   BsSendFill,
 } from 'react-icons/bs'
 
+import { Link, routes } from '@redwoodjs/router'
+
 import { useAuth } from 'src/auth'
 import ArticleTypeIcon, {
   EPostType,
 } from 'src/components/ArticleTypeIcon/ArticleTypeIcon'
 import Button from 'src/components/Button/Button'
 import RenderBody from 'src/components/RenderBody/RenderBody'
-import { timeTag, truncate } from 'src/lib/formatters'
+import { checkboxInputTag, truncate } from 'src/lib/formatters'
+
+import DisplayDatetime from '../DisplayDatetime/DisplayDatetime'
 
 interface Props {
   headers: Array<string>
@@ -24,7 +28,6 @@ interface Props {
 
 const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
   const { currentUser } = useAuth()
-  headers.push('', '', '')
 
   const showDelete = (item) => {
     if (item.__typename === 'Post' && item?.user?.name === currentUser?.name) {
@@ -68,59 +71,86 @@ const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
                   )}
                   {header === 'Author' && <td>{item?.user?.name}</td>}
                   {header === 'Created at' && (
-                    <td>{timeTag(item.createdAt)}</td>
+                    <td>
+                      <DisplayDatetime datetime={item.createdAt} showDate />
+                    </td>
                   )}
+                  {header === 'User id' && <td>{truncate(item.userId)}</td>}
+                  {header === 'Post id' && (
+                    <td>
+                      <Link
+                        to={routes.article({ id: item.postId })}
+                        title={'Show post ' + item.postId + ' detail'}
+                        className="flex flex-row items-center gap-2 text-blue-500 underline hover:text-blue-700"
+                      >
+                        {truncate(item.postId)}
+                      </Link>
+                    </td>
+                  )}
+                  {header === 'Parent id' && <td>{truncate(item.parentId)}</td>}
+                  {header === 'Deleted' && (
+                    <td>{checkboxInputTag(item.deleted)}</td>
+                  )}
+
                   {header === 'Name' && <td>{truncate(item.name)}</td>}
                   {header === 'Description' && (
                     <td>{truncate(item.description)}</td>
                   )}
+                  {header === 'Show' && (
+                    <td>
+                      <nav className="rw-table-actions">
+                        <Button
+                          title={'Show post' + item.id}
+                          onClick={() => onShow(item)}
+                          className="rw-button rw-button-small flex items-center gap-1"
+                          color="rw-gray"
+                          icon={BsSearch}
+                          variant="outlined"
+                        >
+                          <BsSearch />
+                          <span className="hidden lg:inline-block">Show</span>
+                        </Button>
+                      </nav>
+                    </td>
+                  )}
+                  {header === 'Edit' && (
+                    <td>
+                      <nav className="rw-table-actions">
+                        <Button
+                          title={'Edit post' + item.id}
+                          onClick={() => onEdit(item)}
+                          className="rw-button rw-button-small rw-button-blue flex items-center gap-1"
+                          color="cobalt-blue"
+                          variant="outlined"
+                        >
+                          <BsFillPencilFill />
+                          <span className="hidden lg:inline-block">Edit</span>
+                        </Button>
+                      </nav>
+                    </td>
+                  )}
+                  {header === 'Delete' && (
+                    <td>
+                      <nav className="rw-table-actions">
+                        {showDelete(item) && (
+                          <Button
+                            title={'Delete post ' + item.id}
+                            onClick={() => onDelete(item.id)}
+                            className="rw-button rw-button-small rw-button-red flex items-center gap-1"
+                            color="monza-red"
+                            variant="outlined"
+                          >
+                            <BsFillTrash3Fill />
+                            <span className="hidden lg:inline-block">
+                              Delete
+                            </span>
+                          </Button>
+                        )}
+                      </nav>
+                    </td>
+                  )}
                 </>
               ))}
-              <td>
-                <nav className="rw-table-actions">
-                  <Button
-                    title={'Show post' + item.id}
-                    onClick={() => onShow(item)}
-                    className="rw-button rw-button-small flex items-center gap-1"
-                    color="rw-gray"
-                    icon={BsSearch}
-                    variant="outlined"
-                  >
-                    <BsSearch />
-                    <span className="hidden lg:inline-block">Show</span>
-                  </Button>
-                </nav>
-              </td>
-              <td>
-                <nav className="rw-table-actions">
-                  <Button
-                    title={'Edit post' + item.id}
-                    onClick={() => onEdit(item)}
-                    className="rw-button rw-button-small rw-button-blue flex items-center gap-1"
-                    color="cobalt-blue"
-                    variant="outlined"
-                  >
-                    <BsFillPencilFill />
-                    <span className="hidden lg:inline-block">Edit</span>
-                  </Button>
-                </nav>
-              </td>
-              <td>
-                <nav className="rw-table-actions">
-                  {showDelete(item) && (
-                    <Button
-                      title={'Delete post ' + item.id}
-                      onClick={() => onDelete(item.id)}
-                      className="rw-button rw-button-small rw-button-red flex items-center gap-1"
-                      color="monza-red"
-                      variant="outlined"
-                    >
-                      <BsFillTrash3Fill />
-                      <span className="hidden lg:inline-block">Delete</span>
-                    </Button>
-                  )}
-                </nav>
-              </td>
             </tr>
           ))}
         </tbody>

--- a/web/src/components/Table/DashboardTable.tsx
+++ b/web/src/components/Table/DashboardTable.tsx
@@ -24,6 +24,15 @@ interface Props {
 
 const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
   const { currentUser } = useAuth()
+  headers.push('', '', '')
+
+  const showDelete = (item) => {
+    if (item.__typename === 'Post' && item?.user?.name === currentUser?.name) {
+      return true
+    } else if (item.__typename !== 'Post') {
+      return true
+    }
+  }
 
   return (
     <div className="rw-segment rw-table-wrapper-responsive">
@@ -36,25 +45,43 @@ const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
           </tr>
         </thead>
         <tbody>
-          {data.map((post) => (
-            <tr key={post.id}>
-              <td>{truncate(post.id)}</td>
-              <td>{truncate(post.title)}</td>
-              <td>
-                <RenderBody body={truncate(post.body)} />
-              </td>
-              <td>
-                <ArticleTypeIcon type={post.type as EPostType} />
-              </td>
-              <td>{post.published ? <BsSendFill /> : <BsPencilSquare />}</td>
-              <td>{post?.user?.name}</td>
-              <td>{timeTag(post.createdAt)}</td>
+          {data.map((item) => (
+            <tr key={item.id}>
+              {headers.map((header) => (
+                <>
+                  {header === 'Id' && <td>{truncate(item.id)}</td>}
+                  {header === 'Title' && <td>{truncate(item.title)}</td>}
+                  {header === 'Body' && (
+                    <td>
+                      <RenderBody body={truncate(item.body)} />
+                    </td>
+                  )}
+                  {header === 'Type' && (
+                    <td>
+                      <ArticleTypeIcon type={item.type as EPostType} />
+                    </td>
+                  )}
+                  {header === 'Published' && (
+                    <td>
+                      {item.published ? <BsSendFill /> : <BsPencilSquare />}
+                    </td>
+                  )}
+                  {header === 'Author' && <td>{item?.user?.name}</td>}
+                  {header === 'Created at' && (
+                    <td>{timeTag(item.createdAt)}</td>
+                  )}
+                  {header === 'Name' && <td>{truncate(item.name)}</td>}
+                  {header === 'Description' && (
+                    <td>{truncate(item.description)}</td>
+                  )}
+                </>
+              ))}
               <td>
                 <nav className="rw-table-actions">
                   <Button
-                    title={'Show post' + post.id}
-                    onClick={() => onShow(post)}
-                    className="rw-button flex items-center gap-2 text-base transition-colors sm:text-sm"
+                    title={'Show post' + item.id}
+                    onClick={() => onShow(item)}
+                    className="rw-button rw-button-small flex items-center gap-1"
                     color="rw-gray"
                     icon={BsSearch}
                     variant="outlined"
@@ -67,9 +94,9 @@ const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
               <td>
                 <nav className="rw-table-actions">
                   <Button
-                    title={'Edit post' + post.id}
-                    onClick={() => onEdit(post)}
-                    className="rw-button rw-button-blue flex items-center gap-2 text-base transition-colors sm:text-sm"
+                    title={'Edit post' + item.id}
+                    onClick={() => onEdit(item)}
+                    className="rw-button rw-button-small rw-button-blue flex items-center gap-1"
                     color="cobalt-blue"
                     variant="outlined"
                   >
@@ -80,11 +107,11 @@ const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
               </td>
               <td>
                 <nav className="rw-table-actions">
-                  {post?.user?.name === currentUser?.name && (
+                  {showDelete(item) && (
                     <Button
-                      title={'Delete post ' + post.id}
-                      onClick={() => onDelete(post.id)}
-                      className="rw-button rw-button-red flex items-center gap-2 text-base transition-colors sm:text-sm"
+                      title={'Delete post ' + item.id}
+                      onClick={() => onDelete(item.id)}
+                      className="rw-button rw-button-small rw-button-red flex items-center gap-1"
                       color="monza-red"
                       variant="outlined"
                     >

--- a/web/src/components/Table/DashboardTable.tsx
+++ b/web/src/components/Table/DashboardTable.tsx
@@ -54,11 +54,7 @@ const DashboardTable = ({ headers, data, onDelete, onEdit, onShow }: Props) => {
                 <>
                   {header === 'Id' && <td>{truncate(item.id)}</td>}
                   {header === 'Title' && <td>{truncate(item.title)}</td>}
-                  {header === 'Body' && (
-                    <td>
-                      <RenderBody body={truncate(item.body)} />
-                    </td>
-                  )}
+                  {header === 'Body' && <td>{truncate(item.body)}</td>}
                   {header === 'Type' && (
                     <td>
                       <ArticleTypeIcon type={item.type as EPostType} />

--- a/web/src/components/UserModerationCell/UserModerationCell.tsx
+++ b/web/src/components/UserModerationCell/UserModerationCell.tsx
@@ -17,6 +17,7 @@ import { Role } from 'src/types/role'
 
 import Button from '../Button/Button'
 import DisplayDatetime from '../DisplayDatetime/DisplayDatetime'
+import DashboardTable from '../Table/DashboardTable'
 
 export const QUERY = gql`
   query FindUserModerationQuery {

--- a/web/src/components/UserModerationCell/UserModerationCell.tsx
+++ b/web/src/components/UserModerationCell/UserModerationCell.tsx
@@ -253,10 +253,10 @@ export const Success = ({
                       onClick={() => onClickDeleteUser(user as User)}
                     >
                       <BsTrash />
-                      Delete
+                      <span className="hidden lg:inline-block"> Delete </span>
                     </Button>
                   ) : (
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 ">
                       Can&apos;t delete yourself
                     </span>
                   )}

--- a/web/src/components/ViewProfile/ViewProfile.tsx
+++ b/web/src/components/ViewProfile/ViewProfile.tsx
@@ -17,12 +17,7 @@ const ViewProfile = ({ user }: IViewProfileProps) => {
         <h2 className="text-2xl font-bold">Profile</h2>
         {profile ? (
           <div className="mt-3">
-            <Person
-              name={profile.name}
-              quote={profile.japaneseName}
-              imgSrc={profile.avatar}
-              story={profile.bio}
-            />
+            <Person profile={profile} />
           </div>
         ) : (
           <div className="mt-3 text-slate-500">This user has no profile.</div>

--- a/web/src/components/ViewProfile/ViewProfile.tsx
+++ b/web/src/components/ViewProfile/ViewProfile.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { User } from 'types/graphql'
 
 import Person from 'src/pages/AboutPage/Person'
@@ -10,6 +12,16 @@ interface IViewProfileProps {
 
 const ViewProfile = ({ user }: IViewProfileProps) => {
   const { profile, posts = [] } = user
+
+  const sortedPosts = useMemo(() => {
+    if (posts) {
+      return [...posts].sort((a, b) => {
+        if (new Date(a.createdAt) > new Date(b.createdAt)) return -1
+        if (new Date(a.createdAt) < new Date(b.createdAt)) return 1
+        return 0
+      })
+    }
+  }, [posts])
 
   return (
     <div className="grid max-w-6xl gap-8">
@@ -27,8 +39,10 @@ const ViewProfile = ({ user }: IViewProfileProps) => {
         <h2 className="text-2xl font-bold">Posts ({posts.length})</h2>
 
         <div className="mt-3 grid gap-4">
-          {posts.length > 0 ? (
-            posts.map((post) => <ArticlePreview key={post.id} article={post} />)
+          {sortedPosts.length > 0 ? (
+            sortedPosts.map((post) => (
+              <ArticlePreview key={post.id} article={post} />
+            ))
           ) : (
             <div className="text-slate-500">This user has no posts.</div>
           )}

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -1,4 +1,4 @@
-import { BsBoxArrowUp, BsPersonCircle, BsTools } from 'react-icons/bs'
+import { BsBoxArrowUp, BsHouse, BsPersonCircle, BsTools } from 'react-icons/bs'
 
 import { Link, routes } from '@redwoodjs/router'
 import { Toaster } from '@redwoodjs/web/dist/toast'
@@ -62,6 +62,13 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
         {isAuthenticated && currentUser && (
           <div className="fixed top-0 z-20 flex w-full items-center justify-between bg-slate-900 p-3 text-white">
             <div className="flex items-center gap-2">
+              <Link
+                className="flex items-center gap-2 rounded bg-green-800 px-4 py-3 font-semibold uppercase text-white transition hover:bg-cobalt-blue-500 hover:filter sm:text-xs"
+                to={routes.home()}
+              >
+                <BsHouse />
+                <span className="hidden sm:block">Home</span>
+              </Link>
               <Link
                 className="flex items-center gap-2 rounded bg-cobalt-blue-600 px-4 py-3 font-semibold uppercase text-white transition hover:bg-cobalt-blue-500 hover:filter sm:text-xs"
                 to={routes.admin()}

--- a/web/src/pages/AboutPage/Person.tsx
+++ b/web/src/pages/AboutPage/Person.tsx
@@ -1,25 +1,33 @@
+import { Link, routes } from '@redwoodjs/router'
+
 interface Props {
-  name: string
-  quote: string
-  story: string
-  imgSrc: string
+  id?: number
+  profile: object
+  style: string
 }
 
-const Person = ({ name, imgSrc, quote, story }: Props) => {
+const Person = ({ profile, id, style }: Props) => {
   return (
-    <div className="flex flex-row gap-8 rounded border-2 p-2">
+    <div className={`${style} flex flex-row gap-8 rounded border-2 p-2`}>
       <img
-        alt={`Foto van ${name}`}
-        src={imgSrc}
+        alt={`Foto van ${profile.name}`}
+        key={id}
+        src={profile.avatar}
         className="h-48 w-48 items-center justify-center rounded-full bg-slate-300 object-cover"
         loading="lazy"
         width="200"
         height="200"
       />
       <div>
-        <h2 className="h2"> {name} </h2>
-        <h3 className="font-light italic"> {quote} </h3>
-        <p className="pt-2"> {story} </p>
+        <Link
+          to={id ? routes.viewProfile({ id: id }) : '#'}
+          className="hover:underline"
+          title={`View ${profile.name}'s profile`}
+        >
+          <h2 className="h2"> {profile.name} </h2>
+        </Link>
+        <h3 className="font-light italic"> {profile.japaneseName} </h3>
+        <p className="pt-2"> {profile.bio} </p>
       </div>
     </div>
   )

--- a/web/src/pages/AboutPage/Person.tsx
+++ b/web/src/pages/AboutPage/Person.tsx
@@ -1,34 +1,42 @@
+import { BsArrowRightCircle } from 'react-icons/bs'
+
 import { Link, routes } from '@redwoodjs/router'
 
 interface Props {
   id?: number
   profile: object
-  style: string
+  style?: string
 }
 
 const Person = ({ profile, id, style }: Props) => {
   return (
-    <div className={`${style} flex flex-row gap-8 rounded border-2 p-2`}>
-      <img
-        alt={`Foto van ${profile.name}`}
-        key={id}
-        src={profile.avatar}
-        className="h-48 w-48 items-center justify-center rounded-full bg-slate-300 object-cover"
-        loading="lazy"
-        width="200"
-        height="200"
-      />
-      <div>
-        <Link
-          to={id ? routes.viewProfile({ id: id }) : '#'}
-          className="hover:underline"
-          title={`View ${profile.name}'s profile`}
-        >
-          <h2 className="h2"> {profile.name} </h2>
-        </Link>
-        <h3 className="font-light italic"> {profile.japaneseName} </h3>
-        <p className="pt-2"> {profile.bio} </p>
+    <div
+      className={`${style} flex flex-row justify-between gap-8 rounded border-2 p-2`}
+    >
+      <div className="flex flex-row gap-8">
+        <img
+          alt={`Foto van ${profile.name}`}
+          key={id}
+          src={profile.avatar}
+          className="h-48 w-48 items-center justify-center rounded-full bg-slate-300 object-cover"
+          loading="lazy"
+          width="200"
+          height="200"
+        />
+        <div>
+          <Link
+            to={id ? routes.viewProfile({ id: id }) : '#'}
+            className="hover:underline"
+            title={`View ${profile.name}'s profile`}
+          >
+            <h2 className="h2"> {profile.name} </h2>
+          </Link>
+          <h3 className="font-light italic"> {profile.japaneseName} </h3>
+          <p className="pt-2"> {profile.bio} </p>
+        </div>
       </div>
+
+      {style && <BsArrowRightCircle className="text-3xl" />}
     </div>
   )
 }

--- a/web/src/scaffold.css
+++ b/web/src/scaffold.css
@@ -338,7 +338,6 @@
 }
 .rw-table-actions {
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   height: 17px;
   padding-right: 0.25rem;


### PR DESCRIPTION
This PR aims to implement the following:
- [x] Iets meer space tussen titel en meta op uitgelichte afbeelding in post zelf
- [x] Grid in preview is too big on iPad
- [x] Hide 'New Image Gallery' button from dashboard
- [x] Hide 'New comment' button from dashboard
- [x] All dashboards tables the same styling
- [x] Add the profile cards underneath the post & clickable to the view profile page
- [x] Make profile card on reisgezelschap page also clickable to view profile page
- [x] Add Home button to the dasboard bar
- [x] Sort posts on the view profile page: newest on top