### PR TITLE
Feat/170 fix styling

### DIFF
--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -82,31 +82,33 @@ const FullLayout = ({ article }: Props) => {
       {!hasCoverImage && (
         <>
           <header className="mb-4 flex flex-col gap-1">
-            <div className="flex flex-col justify-between gap-2 md:flex-row">
+            <div className="flex flex-row justify-between gap-2">
               <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase tracking-tight md:gap-4">
                 <ArticleTypeIcon type={article.type as EPostType} />
                 {article.title}
-              </h1>{' '}
-              <PostThumbsCell postId={article.id} />
+              </h1>
             </div>
-            <div className="flex flex-row items-center gap-2">
-              <Link
-                to={
-                  article.user?.id
-                    ? routes.viewProfile({ id: article.user?.id })
-                    : '#'
-                }
-                className="text-sm text-slate-500 hover:underline"
-                title={`View ${authorName}'s profile`}
-              >
-                {authorName}
-              </Link>
-              <DisplayDatetime
-                datetime={article.createdAt}
-                showDate={true}
-                className="text-sm text-slate-500"
-              />
-              <LocationPin location={article.location} />
+            <div className="flex flex-row items-center justify-between">
+              <div className="flex flex-row items-center gap-2">
+                <Link
+                  to={
+                    article.user?.id
+                      ? routes.viewProfile({ id: article.user?.id })
+                      : '#'
+                  }
+                  className="text-sm text-slate-500 hover:underline"
+                  title={`View ${authorName}'s profile`}
+                >
+                  {authorName}
+                </Link>
+                <DisplayDatetime
+                  datetime={article.createdAt}
+                  showDate={true}
+                  className="text-sm text-slate-500"
+                />
+                <LocationPin location={article.location} />
+              </div>
+              <PostThumbsCell postId={article.id} />
             </div>
           </header>
         </>

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -72,9 +72,9 @@ const FullLayout = ({ article }: Props) => {
               />
               <LocationPin location={article.location} className="text-white" />
             </div>
-          </div>
-          <div className="absolute bottom-2 right-2 rounded bg-white p-1">
-            <PostThumbsCell postId={article.id} />
+            <div className="absolute bottom-2 right-2 rounded bg-slate-300 bg-opacity-70 p-1">
+              <PostThumbsCell postId={article.id} />
+            </div>
           </div>
         </section>
       )}

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -116,7 +116,7 @@ const FullLayout = ({ article }: Props) => {
         {article.videoPost != null && (
           <Video embedUrl={article?.videoPost?.videoUrl} />
         )}
-        <RenderBody body={article.body} />
+        <RenderBody body={article.body} className="leading-7 text-[#374151]" />
       </div>
 
       {galleries &&

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -112,7 +112,7 @@ const FullLayout = ({ article }: Props) => {
         </>
       )}
 
-      <div>
+      <div className="w-full">
         {article.videoPost != null && (
           <Video embedUrl={article?.videoPost?.videoUrl} />
         )}

--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -70,7 +70,10 @@ const FullLayout = ({ article }: Props) => {
                 showDate={true}
                 className="text-sm text-slate-200"
               />
-              <LocationPin location={article.location} className="text-white" />
+              <LocationPin
+                location={article.location}
+                className="pb-1 text-white"
+              />
             </div>
             <div className="absolute bottom-2 right-2 rounded bg-slate-300 bg-opacity-70 p-1">
               <PostThumbsCell postId={article.id} />
@@ -100,13 +103,16 @@ const FullLayout = ({ article }: Props) => {
                   title={`View ${authorName}'s profile`}
                 >
                   {authorName}
-                </Link>
+                </Link>{' '}
                 <DisplayDatetime
                   datetime={article.createdAt}
                   showDate={true}
                   className="text-sm text-slate-500"
                 />
-                <LocationPin location={article.location} />
+                <LocationPin
+                  location={article.location}
+                  className="pb-1 text-slate-500"
+                />
               </div>
               <PostThumbsCell postId={article.id} />
             </div>

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -41,7 +41,7 @@ const PreviewLayout = ({ article }: Props) => {
           {article.type === EPostType.ARTICLE && (
             <RenderBody
               body={article.body}
-              className="!prose-invert mx-auto mb-8  line-clamp-3 text-center"
+              className="prose mx-auto mb-8 line-clamp-3 text-center text-[#d1d5db]"
             />
           )}
           <div className="flex flex-row items-center justify-center gap-12">

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -45,23 +45,7 @@ const PreviewLayout = ({ article }: Props) => {
             />
           )}
           <div className="flex flex-row items-center justify-center gap-12">
-            <div className="flex flex-row items-center gap-2">
-              <Avatar
-                src={article.user?.profile?.avatar}
-                alt={article.user.name}
-                name={article.user.name || article.user.email}
-                userId={article.user?.id}
-              />
-              <div className="flex flex-col items-start">
-                <span className="text-sm text-slate-300" title={authorName}>
-                  {authorName}
-                </span>
-                <DisplayDatetime
-                  className="text-sm text-slate-300"
-                  datetime={article.createdAt}
-                />
-              </div>
-            </div>
+            <AvatarTimestamp article={article} hasImage={hasImage} />
             {article?.comments?.length > 0 && (
               <ArticleCommentCountBadge count={article.comments.length} />
             )}
@@ -114,7 +98,7 @@ const PreviewLayout = ({ article }: Props) => {
             )}
 
             <div className="flex items-center justify-between pt-4">
-              <AvatarTimestamp article={article} />
+              <AvatarTimestamp article={article} hasImage={hasImage} />
               <div className="flex items-center gap-6">
                 {article?.comments?.length > 0 && (
                   <ArticleCommentCountBadge

--- a/web/src/components/Avatar/AvatarTimestamp/AvatarTimestamp.tsx
+++ b/web/src/components/Avatar/AvatarTimestamp/AvatarTimestamp.tsx
@@ -3,35 +3,52 @@ import { Post } from 'types/graphql'
 import Avatar from 'src/components/Avatar/Avatar'
 import DisplayDatetime from 'src/components/DisplayDatetime/DisplayDatetime'
 import LocationPin from 'src/components/LocationPin/LocationPin'
+import { classNames } from 'src/lib/class-names'
 
 interface Props {
   article: Post
+  hasImage?: boolean
 }
 
-const AvatarTimestamp = ({ article }: Props) => {
+const AvatarTimestamp = ({ article, hasImage }: Props) => {
   const authorName =
     article.user.profile?.name || article.user.name || 'Anonymous'
 
   return (
-    <div className="mb-2 flex flex-row items-center gap-2">
-      <Avatar
-        src={article.user?.profile?.avatar}
-        alt={authorName}
-        name={authorName}
-      />
-      <div>
-        <span
-          className="text-sm text-slate-500"
-          title={article.user.name || article.user.email}
-        >
-          {authorName}
-        </span>
-
-        <DisplayDatetime
-          datetime={article.createdAt}
-          className="text-sm text-slate-500"
+    <div className="flex gap-2">
+      <div className="flex flex-row items-center gap-2">
+        <Avatar
+          src={article.user?.profile?.avatar}
+          alt={authorName}
+          name={authorName}
         />
-        <LocationPin location={article.location} className="text-white" />
+        <div>
+          <span
+            className={classNames(
+              'text-sm',
+              hasImage ? 'text-white' : 'text-slate-500'
+            )}
+            title={article.user.name || article.user.email}
+          >
+            {authorName}
+          </span>
+          <DisplayDatetime
+            datetime={article.createdAt}
+            className={classNames(
+              'text-sm',
+              hasImage ? 'text-white' : 'text-slate-500'
+            )}
+          />
+        </div>
+      </div>
+      <div className="mb-1 flex items-end">
+        <LocationPin
+          location={article.location}
+          className={classNames(
+            'text-sm',
+            hasImage ? 'text-white' : 'text-slate-500'
+          )}
+        />
       </div>
     </div>
   )

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -35,7 +35,7 @@ const Button = ({
       aria-label={text}
       title={title ? title : text ? text : ''}
       disabled={disabled}
-      className={`block rounded px-2 py-1 text-xs font-semibold uppercase lg:px-4 lg:py-3
+      className={`block rounded px-1 py-1 font-semibold uppercase lg:px-2 lg:py-2
       ${disabled ? 'cursor-not-allowed opacity-50' : ''}
       ${buttonColors}
       ${className}

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -35,7 +35,7 @@ const Button = ({
       aria-label={text}
       title={title ? title : text ? text : ''}
       disabled={disabled}
-      className={`block rounded px-3 py-2 font-semibold uppercase
+      className={`block rounded px-2 py-1 text-xs font-semibold uppercase lg:px-4 lg:py-3
       ${disabled ? 'cursor-not-allowed opacity-50' : ''}
       ${buttonColors}
       ${className}

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -35,7 +35,7 @@ const Button = ({
       aria-label={text}
       title={title ? title : text ? text : ''}
       disabled={disabled}
-      className={`block rounded px-1 py-1 font-semibold uppercase lg:px-2 lg:py-2
+      className={`block rounded px-2 py-1 font-semibold uppercase lg:px-3 lg:py-3
       ${disabled ? 'cursor-not-allowed opacity-50' : ''}
       ${buttonColors}
       ${className}

--- a/web/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/web/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -43,7 +43,7 @@ const MarkdownEditor = ({
       <div className="mt-2 flex flex-row rounded-md">
         <button
           className={classNames(
-            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700',
+            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-2 py-1 font-bold text-white hover:bg-blue-700 md:px-4 md:py-2',
             previewState === 'EDIT' ? 'bg-blue-700' : ''
           )}
           onClick={() => {
@@ -52,12 +52,12 @@ const MarkdownEditor = ({
           type="button"
         >
           <BsPencil />
-          Edit
+          <span className="hidden lg:inline-block">Edit</span>
         </button>
 
         <button
           className={classNames(
-            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700',
+            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-2 py-1 font-bold text-white hover:bg-blue-700 md:px-4 md:py-2',
             previewState === 'SPLIT' ? 'bg-blue-700' : ''
           )}
           onClick={() => {
@@ -66,11 +66,11 @@ const MarkdownEditor = ({
           type="button"
         >
           <BsLayoutSplit />
-          Split
+          <span className="hidden lg:inline-block">Split</span>
         </button>
         <button
           className={classNames(
-            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700',
+            'w-30 flex flex-row items-center gap-2 bg-blue-500 px-2 py-1 font-bold text-white hover:bg-blue-700 md:px-4 md:py-2',
             previewState === 'PREVIEW' ? 'bg-blue-700' : ''
           )}
           onClick={() => {
@@ -79,16 +79,16 @@ const MarkdownEditor = ({
           type="button"
         >
           <BsEyeglasses />
-          Preview
+          <span className="hidden lg:inline-block">Preview</span>
         </button>
         <a
           href="https://www.markdownguide.org/basic-syntax/"
           target="_blank"
           rel="noopener noreferrer"
-          className="w-30 ml-auto flex flex-row items-center gap-2 px-4 py-2 font-bold text-blue-700 hover:text-blue-900 hover:underline"
+          className="w-30 ml-auto flex flex-row items-center gap-2 px-1 py-1 font-bold text-blue-700 hover:text-blue-900 hover:underline md:px-4 md:py-2"
         >
           <BsQuestionCircle />
-          Markdown cheatsheet
+          Edit tips
           <BsBoxArrowUpRight />
         </a>
       </div>

--- a/web/src/components/RenderBody/RenderBody.tsx
+++ b/web/src/components/RenderBody/RenderBody.tsx
@@ -10,13 +10,7 @@ interface IRenderBodyProps {
 }
 
 const RenderBody = ({ className, body }: IRenderBodyProps) => {
-  return (
-    <ReactMarkdown
-      className={classNames('leading-7 text-[#374151]', className)}
-    >
-      {body}
-    </ReactMarkdown>
-  )
+  return <ReactMarkdown className={classNames(className)}>{body}</ReactMarkdown>
 }
 
 export default RenderBody

--- a/web/src/components/RenderBody/RenderBody.tsx
+++ b/web/src/components/RenderBody/RenderBody.tsx
@@ -12,10 +12,7 @@ interface IRenderBodyProps {
 const RenderBody = ({ className, body }: IRenderBodyProps) => {
   return (
     <ReactMarkdown
-      className={classNames(
-        'prose prose-sm sm:prose lg:prose-lg xl:prose-xl',
-        className
-      )}
+      className={classNames('leading-7 text-[#374151]', className)}
     >
       {body}
     </ReactMarkdown>

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -35,12 +35,12 @@ const Thumb = ({
       onClick={disabled ? undefined : onClick}
       variant={active ? 'filled' : 'outlined'}
       className={classNames(
-        'transition-filter whitespace-nowrap',
+        'transition-filter whitespace-nowrap lg:py-1',
         disabled ? 'cursor-not-allowed grayscale' : ''
       )}
       title={title}
     >
-      <div className="flex flex-row items-center gap-1">
+      <div className="flex flex-row items-center gap-1 ">
         {up && count > 0 ? (
           <BsHandThumbsUpFill />
         ) : up ? (

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -28,7 +28,7 @@ const Thumb = ({
       onClick={disabled ? undefined : onClick}
       variant={active ? 'filled' : 'outlined'}
       className={classNames(
-        'transition-filter whitespace-nowrap',
+        'transition-filter whitespace-nowrap lg:text-base',
         disabled ? 'cursor-not-allowed grayscale' : ''
       )}
       title={title}

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -35,12 +35,12 @@ const Thumb = ({
       onClick={disabled ? undefined : onClick}
       variant={active ? 'filled' : 'outlined'}
       className={classNames(
-        'transition-filter whitespace-nowrap lg:py-1',
+        'transition-filter whitespace-nowrap text-sm md:text-base lg:py-1 lg:text-lg',
         disabled ? 'cursor-not-allowed grayscale' : ''
       )}
       title={title}
     >
-      <div className="flex flex-row items-center gap-1 ">
+      <div className="flex flex-row items-center gap-1">
         {up && count > 0 ? (
           <BsHandThumbsUpFill />
         ) : up ? (

--- a/web/src/components/Thumb/Thumb.tsx
+++ b/web/src/components/Thumb/Thumb.tsx
@@ -1,5 +1,12 @@
 import { useMemo } from 'react'
 
+import {
+  BsHandThumbsDown,
+  BsHandThumbsDownFill,
+  BsHandThumbsUp,
+  BsHandThumbsUpFill,
+} from 'react-icons/bs'
+
 import { classNames } from 'src/lib/class-names'
 
 import Button from '../Button/Button'
@@ -28,12 +35,23 @@ const Thumb = ({
       onClick={disabled ? undefined : onClick}
       variant={active ? 'filled' : 'outlined'}
       className={classNames(
-        'transition-filter whitespace-nowrap lg:text-base',
+        'transition-filter whitespace-nowrap',
         disabled ? 'cursor-not-allowed grayscale' : ''
       )}
       title={title}
     >
-      {up ? '👍' : '👎'} {count}
+      <div className="flex flex-row items-center gap-1">
+        {up && count > 0 ? (
+          <BsHandThumbsUpFill />
+        ) : up ? (
+          <BsHandThumbsUp />
+        ) : count > 0 ? (
+          <BsHandThumbsDownFill />
+        ) : (
+          <BsHandThumbsDown />
+        )}
+        {count}
+      </div>
     </Button>
   )
 }

--- a/web/src/components/Thumbs/Thumbs.tsx
+++ b/web/src/components/Thumbs/Thumbs.tsx
@@ -43,7 +43,7 @@ const Thumbs = (props: IThumbProps) => {
   }, [props.thumbs, currentUser])
 
   return (
-    <div className={classNames('flex gap-2', className)}>
+    <div className={classNames('flex gap-1', className)}>
       <Thumb
         up={true}
         count={upCount}

--- a/web/src/components/UserComment/Comment.tsx
+++ b/web/src/components/UserComment/Comment.tsx
@@ -160,30 +160,31 @@ export default ({ comment, onClickReply }: ICommentProps) => {
               variant="outlined"
             >
               <BsReplyFill />
-              Reply
+              <span className="text-xs lg:text-base">Reply</span>
             </Button>
           )}
-
-          <Thumbs
-            thumbs={comment.thumbs}
-            onThumb={handleThumbClick}
-            disabled={thumbsDisabled}
-          />
         </div>
       </div>
       <div className="ml-14 mt-4 text-sm leading-relaxed text-slate-600">
         <RenderBody body={comment.body} />
       </div>
-      {currentUser?.id === comment.user.id && (
-        <Button
-          onClick={handleDelete}
-          className="user-select-none bottom-2 right-2 ml-auto mt-3 transition-opacity group-hover:cursor-pointer group-hover:opacity-100 md:absolute md:mt-0 md:opacity-0"
-          color="monza-red"
-          title="Delete comment"
-        >
-          <BsTrash />
-        </Button>
-      )}
+      <div className="flex flex-row items-center justify-end gap-2">
+        <Thumbs
+          thumbs={comment.thumbs}
+          onThumb={handleThumbClick}
+          disabled={thumbsDisabled}
+        />
+        {currentUser?.id === comment.user.id && (
+          <Button
+            onClick={handleDelete}
+            className="user-select-none transition-opacity group-hover:cursor-pointer group-hover:opacity-100 md:absolute md:mt-0 md:opacity-0"
+            color="monza-red"
+            title="Delete comment"
+          >
+            <BsTrash />
+          </Button>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/layouts/AdminDashboardLayout/AdminDashboardLayout.tsx
+++ b/web/src/layouts/AdminDashboardLayout/AdminDashboardLayout.tsx
@@ -102,13 +102,13 @@ const AdminDashboardLayout = ({ children }: AdminDashboardLayoutProps) => {
 
   return (
     <div className="flex flex-row">
-      <div className="fixed flex h-screen w-14 flex-col justify-between bg-gray-200 lg:w-64">
+      <div className="fixed flex h-screen w-8 flex-col justify-between bg-gray-200 md:w-14 lg:w-64">
         <div>
           <div className="p-1 lg:p-3 lg:text-center">
             <h1 className="flex items-center justify-between text-xl font-bold lg:text-3xl">
               <span className="hidden lg:inline">Dashboard</span>
               <img
-                className="inline h-12 w-12"
+                className="inline h-6 w-6 md:h-12 md:w-12"
                 alt="Logo"
                 src="/images/logo.png"
                 width="48"
@@ -135,7 +135,7 @@ const AdminDashboardLayout = ({ children }: AdminDashboardLayoutProps) => {
                     )}`}
                     to={item.path}
                   >
-                    <span className="mx-auto text-lg md:my-2 lg:mx-0">
+                    <span className="mx-auto md:my-2 md:text-lg lg:mx-0">
                       {item.icon}
                     </span>
                     <span className="hidden lg:inline-block">{item.name}</span>
@@ -146,24 +146,24 @@ const AdminDashboardLayout = ({ children }: AdminDashboardLayoutProps) => {
           </nav>
         </div>
         {isAuthenticated ? (
-          <div className="flex items-center justify-between bg-slate-500 p-1 text-white lg:p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2 bg-slate-500 p-0.5 text-white md:p-1 lg:p-3">
             <span className="hidden lg:block">
               Logged in as {currentUser.email}
             </span>
             <Button
               onClick={logOut}
               color="monza-red"
-              className="flex items-center gap-2 px-4 py-3 lg:text-sm"
+              className="flex items-center gap-2 text-xs md:text-sm"
             >
               <BsBoxArrowUp />
-              <span className="hidden lg:block ">Uitloggen</span>
+              <span className="hidden text-xs lg:block">Uitloggen</span>
             </Button>
           </div>
         ) : (
           <Link to={routes.login()}>Inloggen</Link>
         )}
       </div>
-      <div className="flex flex-1 flex-col overflow-auto pl-14 lg:pl-64">
+      <div className="flex flex-1 flex-col overflow-auto pl-8 md:pl-14 lg:pl-64">
         {children}
       </div>
     </div>

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -33,7 +33,10 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
           </h1>
           <Skeleton width={100} className="mx-auto mt-2 rounded" />
           <nav>
-            <ul className="mt-3 flex justify-center gap-5">
+            <ul className="mt-3 flex justify-center gap-2">
+              <li>
+                <Skeleton width={50} className="rounded" />
+              </li>
               <li>
                 <Skeleton width={50} className="rounded" />
               </li>
@@ -118,7 +121,7 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
         </h1>
         <pre className="mt-3">Japan 2023</pre>
         <nav>
-          <ul className="mt-3 flex justify-center gap-5">
+          <ul className="mt-3 flex flex-wrap justify-center gap-2">
             <li>
               <Link className="rw-button" to={routes.home()}>
                 Blog
@@ -142,7 +145,7 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
           </ul>
         </nav>
       </header>
-      <main className="mx-auto grid max-w-6xl">{children}</main>
+      <main className="max-w-6x mx-auto md:grid">{children}</main>
     </>
   )
 }

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -102,7 +102,7 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
           </div>
         )}
         <div className={`mx-auto w-32 ${isAuthenticated && 'mt-16'}`}>
-          <Link to={routes.home()} title="Ohayou Goededagu" aria-label="Home">
+          <Link to={routes.home()} title="Ohayo Goededagu" aria-label="Home">
             <img
               src="/images/logo.png"
               className="mx-auto origin-top rounded-b-full shadow-lg transition duration-500 ease-in-out hover:scale-110 hover:transform hover:shadow-xl"
@@ -113,7 +113,7 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
           </Link>
         </div>
         <h1 className="pt-3 text-3xl font-bold">
-          <span className="whitespace-nowrap">Ohayou&nbsp;Goededagu</span> |{' '}
+          <span className="whitespace-nowrap">Ohayo&nbsp;Goededagu</span> |{' '}
           <span className="whitespace-nowrap">おはよ&nbsp;グデダギュ</span>
         </h1>
         <pre className="mt-3">Japan 2023</pre>

--- a/web/src/layouts/BlogLayout/BlogLayout.tsx
+++ b/web/src/layouts/BlogLayout/BlogLayout.tsx
@@ -145,7 +145,7 @@ const BlogLayout = ({ children, skeleton }: BlogLayoutProps) => {
           </ul>
         </nav>
       </header>
-      <main className="max-w-6x mx-auto md:grid">{children}</main>
+      <main className="mx-auto max-w-6xl md:grid">{children}</main>
     </>
   )
 }


### PR DESCRIPTION
This PR aims to improve several styling things of issues #167, #168 & #170:

Like post button:
- On mobile the like buttons should be moved to the right in article types haiku, chotto, video & photo gallery
- On mobile the like buttons overlap the title
- Make the like buttons background transparent in type article, might look nicer

General styling:
- Text in article doesn't take up full width
- Issues with location pin: not right color in full view, not visible on blog roll, not aligned with text anywhere
- In the dashboard the logout button was floating outside the menu bar

Mobile:
- The page overlaps, you have to scroll out to see the entire page
- The blog-vlog etc buttons are not centered
- Less room for the dashboard menu bar, and more for editing a post
