### PR TITLE
Added: Post filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 
 # Database settings
 DATABASE_URL="postgresql://xxxxxxxxxx:xxxxxxxxxxxxxxxx@localhost:5432/postgres"
-TEST_DATABASE_URL="postgresql://xxxxxxxxxxx:xxxxxxxxxxxxxxxx@localhost:5432/postgres"
+TEST_DATABASE_URL="postgresql://xxxxxxxxxxx:xxxxxxxxxxxxxxxx@localhost:5433/postgres" # Note: The test db uses port 5433 instead of 5432
 
 # Cloudinary settings
 CLOUD_NAME=xxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ api/src/lib/generateGraphiQLHeader.*
 !.yarn/versions
 
 data
+data_test

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -21,6 +21,8 @@ export const schema = gql`
     perPage: Int
     authors: [Int!]
     postTypes: [String!]
+    from: DateTime
+    to: DateTime
   }
 
   type Query {

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -18,10 +18,21 @@ export const schema = gql`
 
   type PostWithPaginationAndFilters {
     posts: [Post!]!
+    pagination: Pagination!
+    activeFilters: ActiveFilters!
+  }
+
+  type Pagination {
     count: Int!
     page: Int!
     perPage: Int!
-    activeFilters: [String!]!
+  }
+
+  type ActiveFilters {
+    authors: [Int!]!
+    postTypes: [String!]!
+    from: DateTime
+    to: DateTime
   }
 
   input QueryPostsInput {

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -16,6 +16,14 @@ export const schema = gql`
     postThumbs: [PostThumb]!
   }
 
+  type PostWithPaginationAndFilters {
+    posts: [Post!]!
+    count: Int!
+    page: Int!
+    perPage: Int!
+    activeFilters: [String!]!
+  }
+
   input QueryPostsInput {
     page: Int
     perPage: Int
@@ -26,7 +34,7 @@ export const schema = gql`
   }
 
   type Query {
-    posts(input: QueryPostsInput): [Post!]! @skipAuth
+    posts(input: QueryPostsInput): PostWithPaginationAndFilters! @skipAuth
     allPosts: [Post!]! @skipAuth
     post(id: Int!): Post @skipAuth
   }

--- a/api/src/graphql/posts.sdl.ts
+++ b/api/src/graphql/posts.sdl.ts
@@ -16,8 +16,15 @@ export const schema = gql`
     postThumbs: [PostThumb]!
   }
 
+  input QueryPostsInput {
+    page: Int
+    perPage: Int
+    authors: [Int!]
+    postTypes: [String!]
+  }
+
   type Query {
-    posts: [Post!]! @skipAuth
+    posts(input: QueryPostsInput): [Post!]! @skipAuth
     allPosts: [Post!]! @skipAuth
     post(id: Int!): Post @skipAuth
   }

--- a/api/src/services/posts/posts.test.ts
+++ b/api/src/services/posts/posts.test.ts
@@ -24,7 +24,8 @@ describe('posts', () => {
 
       const result = await posts({ input })
 
-      expect(result.length).toEqual(Object.keys(scenario.post).length)
+      expect(result.posts.length).toEqual(Object.keys(scenario.post).length)
+      expect(result.pagination.count).toEqual(Object.keys(scenario.post).length)
     }
   )
 

--- a/api/src/services/posts/posts.test.ts
+++ b/api/src/services/posts/posts.test.ts
@@ -1,3 +1,5 @@
+import { QueryPostsInput } from 'types/graphql'
+
 import { posts, allPosts, post } from './posts'
 import type { StandardScenario } from './posts.scenarios'
 
@@ -11,7 +13,16 @@ describe('posts', () => {
   scenario(
     'returns all published posts',
     async (scenario: StandardScenario) => {
-      const result = await posts()
+      const input: QueryPostsInput = {
+        page: 1,
+        perPage: 10,
+        authors: [],
+        postTypes: [],
+        from: null,
+        to: null,
+      }
+
+      const result = await posts({ input })
 
       expect(result.length).toEqual(Object.keys(scenario.post).length)
     }

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -2,7 +2,7 @@ import { PostRelationResolvers } from 'types/graphql'
 
 import { db } from 'src/lib/db'
 
-export const posts = ({ input }: { input: QueryPostsInput }) => {
+export const posts = async ({ input }: { input: QueryPostsInput }) => {
   const {
     page = 1,
     perPage = 10,
@@ -47,12 +47,22 @@ export const posts = ({ input }: { input: QueryPostsInput }) => {
     }
   }
 
-  return db.post.findMany({
+  const result = await db.post.findMany({
     where,
     orderBy: { createdAt: 'desc' },
     skip: (page - 1) * perPage,
     take: perPage,
   })
+
+  const count = await db.post.count({ where })
+
+  return {
+    posts: result,
+    count,
+    page,
+    perPage,
+    activeFilters: [...authors, ...postTypes],
+  }
 }
 
 export const allPosts = () => {

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -3,7 +3,14 @@ import { PostRelationResolvers } from 'types/graphql'
 import { db } from 'src/lib/db'
 
 export const posts = ({ input }: { input: QueryPostsInput }) => {
-  const { page = 1, perPage = 10, authors = [], postTypes = [] } = input
+  const {
+    page = 1,
+    perPage = 10,
+    authors = [],
+    postTypes = [],
+    from = null,
+    to = null,
+  } = input
 
   let where = {
     published: true,
@@ -20,6 +27,23 @@ export const posts = ({ input }: { input: QueryPostsInput }) => {
     where = {
       ...where,
       type: { in: postTypes },
+    }
+  }
+
+  if (from && to) {
+    where = {
+      ...where,
+      createdAt: { gte: from, lte: to },
+    }
+  } else if (from) {
+    where = {
+      ...where,
+      createdAt: { gte: from },
+    }
+  } else if (to) {
+    where = {
+      ...where,
+      createdAt: { lte: to },
     }
   }
 

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -58,10 +58,17 @@ export const posts = async ({ input }: { input: QueryPostsInput }) => {
 
   return {
     posts: result,
-    count,
-    page,
-    perPage,
-    activeFilters: [...authors, ...postTypes],
+    pagination: {
+      count,
+      page,
+      perPage,
+    },
+    activeFilters: {
+      authors,
+      postTypes,
+      from,
+      to,
+    },
   }
 }
 

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -1,4 +1,4 @@
-import { PostRelationResolvers } from 'types/graphql'
+import { PostRelationResolvers, QueryPostsInput } from 'types/graphql'
 
 import { db } from 'src/lib/db'
 

--- a/api/src/services/posts/posts.ts
+++ b/api/src/services/posts/posts.ts
@@ -2,10 +2,32 @@ import { PostRelationResolvers } from 'types/graphql'
 
 import { db } from 'src/lib/db'
 
-export const posts = () => {
+export const posts = ({ input }: { input: QueryPostsInput }) => {
+  const { page = 1, perPage = 10, authors = [], postTypes = [] } = input
+
+  let where = {
+    published: true,
+  }
+
+  if (authors.length > 0) {
+    where = {
+      ...where,
+      userId: { in: authors },
+    }
+  }
+
+  if (postTypes.length > 0) {
+    where = {
+      ...where,
+      type: { in: postTypes },
+    }
+  }
+
   return db.post.findMany({
-    where: { published: true },
+    where,
     orderBy: { createdAt: 'desc' },
+    skip: (page - 1) * perPage,
+    take: perPage,
   })
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,16 @@ services:
     ports:
       - 5432:5432
 
+  db_test:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: mysecretpassword
+    volumes:
+      - ./data_test:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+
 volumes:
   postgres_data:
     driver: local

--- a/scripts/helpers/generate-many-posts.ts
+++ b/scripts/helpers/generate-many-posts.ts
@@ -1,0 +1,47 @@
+import getImageGalleriesCreateCommand from './create-image-galleries-command'
+
+function generateManyPosts(amount: number) {
+  const posts = []
+
+  for (let i = 0; i < amount; i++) {
+    const postType =
+      i % 5 === 0
+        ? 'ARTICLE'
+        : i % 5 === 1
+        ? 'CHOTTO'
+        : i % 5 === 2
+        ? 'PHOTO_GALLERY'
+        : i % 5 === 3
+        ? 'VIDEO'
+        : 'HAIKU'
+
+    const post = {
+      title: `Post ${i + 1}`,
+      body: `This is my post number ${i + 1}`,
+      published: true,
+      userId: 1,
+      location: '1 Chome-1-2 Oshiage, Sumida City, Tokyo 131-0045, Japan',
+      type: postType,
+    }
+
+    if (postType === 'PHOTO_GALLERY') {
+      post.imageGalleries = getImageGalleriesCreateCommand({
+        galleriesAmount: 1,
+        imagesAmount: 13,
+      })
+    }
+
+    if (postType === 'VIDEO') {
+      post.videoPost = {
+        create: {
+          videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        },
+      }
+    }
+
+    posts.push(post)
+  }
+  return posts
+}
+
+export default generateManyPosts

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,6 +4,7 @@ import { db } from 'api/src/lib/db'
 import { hashPassword } from '@redwoodjs/auth-dbauth-api'
 
 import getImageGalleriesCreateCommand from './helpers/create-image-galleries-command'
+import generateManyPosts from './helpers/generate-many-posts'
 
 export default async () => {
   try {
@@ -48,6 +49,15 @@ export default async () => {
         email: 'admin@example.com',
         password: 'Test1234!',
         roles: ['ADMIN'],
+        profile: {
+          create: {
+            bio: 'I am an admin',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'Admin',
+            japaneseName: 'アドミン',
+          },
+        },
       },
       {
         name: 'drikus',
@@ -64,25 +74,78 @@ export default async () => {
           },
         },
       },
-      { name: 'john', email: 'john@example.com', password: 'secret1' },
-      { name: 'jane', email: 'jane@example.com', password: 'secret2' },
+      {
+        name: 'john',
+        email: 'john@example.com',
+        password: 'secret1',
+        profile: {
+          create: {
+            bio: 'I am a software developer',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'John',
+            japaneseName: 'ジョン',
+          },
+        },
+      },
+      {
+        name: 'jane',
+        email: 'jane@example.com',
+        password: 'secret2',
+        profile: {
+          create: {
+            bio: 'I am a software developer',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'John',
+            japaneseName: 'ジョン',
+          },
+        },
+      },
       {
         name: 'naomi',
         email: 'nreliasar@gmail.com',
         password: 'Test1234!',
         roles: ['GUEST', 'USER', 'MODERATOR', 'ADMIN'],
+        profile: {
+          create: {
+            bio: 'I am a software developer',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'Naomi Reliasar',
+            japaneseName: 'ナオミ レリアサー',
+          },
+        },
       },
       {
         name: 'moeder is guest',
         email: 'memoeder@example.com',
         password: 'Test1234!',
         roles: ['GUEST'],
+        profile: {
+          create: {
+            bio: 'I am a software developer',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'Naomi Reliasar',
+            japaneseName: 'ナオミ レリアサー',
+          },
+        },
       },
       {
         name: 'vader is user',
         email: 'mevader@example.com',
         password: 'Test1234!',
         roles: ['USER'],
+        profile: {
+          create: {
+            bio: 'I am a software developer',
+            avatar:
+              'https://thumbs.dreamstime.com/b/cat-as-mailman-post-delivery-service-postman-illustration-generative-ai-cat-as-mailman-mail-post-delivery-service-postman-268937340.jpg',
+            name: 'Naomi Reliasar',
+            japaneseName: 'ナオミ レリアサー',
+          },
+        },
       },
     ]
 
@@ -138,6 +201,7 @@ export default async () => {
           'Shibuya Scramble Crossing, 21 Udagawa-cho, Shibuya City, Tokyo, Japan',
         type: 'PHOTO_GALLERY',
       },
+      ...generateManyPosts(25),
     ]
 
     for (const post of posts) {

--- a/web/src/components/ArticlesCell/ArticlesCell.mock.ts
+++ b/web/src/components/ArticlesCell/ArticlesCell.mock.ts
@@ -1,4 +1,15 @@
 // Define your own mock data here:
 export const standard = (/* vars, { ctx, req } */) => ({
-  articles: [{ id: 42 }, { id: 43 }, { id: 44 }],
+  posts: [{ id: 42 }, { id: 43 }, { id: 44 }],
+  pagination: {
+    count: 3,
+    page: 1,
+    perPage: 10,
+  },
+  activeFilters: {
+    authors: [],
+    postTypes: [],
+    from: null,
+    to: null,
+  },
 })

--- a/web/src/components/ArticlesCell/ArticlesCell.test.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.test.tsx
@@ -36,7 +36,7 @@ describe('ArticlesCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success articles={standard().articles} />)
+      render(<Success result={standard()} />)
     }).not.toThrow()
   })
 })

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -82,39 +82,7 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ result, vlog, gallery }: Props) => {
-  const vlogs = result.posts.filter((article) => {
-    if (article.type === EPostType.VIDEO) {
-      return article
-    }
-  })
-
-  const galleries = result.posts.filter((article) => {
-    if (article.type === EPostType.PHOTO_GALLERY) {
-      return article
-    }
-  })
-
-  if (vlog) {
-    return (
-      <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
-        {vlogs.map((article) => {
-          return <ArticlePreview key={article.id} article={article} />
-        })}
-      </ul>
-    )
-  }
-
-  if (gallery) {
-    return (
-      <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
-        {galleries.map((article) => {
-          return <ArticlePreview key={article.id} article={article} />
-        })}
-      </ul>
-    )
-  }
-
+export const Success = ({ result }: Props) => {
   return (
     <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
       {result.posts.map((article) => {

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -3,7 +3,7 @@ import type { ArticlesQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 import ArticlePreview from '../Article/components/ArticlePreview/ArticlePreview'
-import { EPostType } from '../ArticleTypeIcon/ArticleTypeIcon'
+import Pagination from '../Pagination/Pagination'
 import Skeleton from '../Skeleton/Skeleton'
 
 export const QUERY = gql`
@@ -82,12 +82,22 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ result }: Props) => {
+export const Success = ({ result, vlog, gallery }: Props) => {
+  const { posts, pagination } = result
+
   return (
-    <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
-      {result.posts.map((article) => {
-        return <ArticlePreview key={article.id} article={article} />
-      })}
-    </ul>
+    <>
+      <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
+        {posts.map((article) => {
+          return <ArticlePreview key={article.id} article={article} />
+        })}
+      </ul>
+      <div className="py-10">
+        <Pagination
+          pagination={pagination}
+          routeName={vlog ? 'vlog' : gallery ? 'galleries' : 'home'}
+        />
+      </div>
+    </>
   )
 }

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -7,8 +7,8 @@ import { EPostType } from '../ArticleTypeIcon/ArticleTypeIcon'
 import Skeleton from '../Skeleton/Skeleton'
 
 export const QUERY = gql`
-  query ArticlesQuery {
-    articles: posts {
+  query ArticlesQuery($input: QueryPostsInput) {
+    articles: posts(input: $input) {
       id
       title
       body

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -45,10 +45,17 @@ export const QUERY = gql`
           }
         }
       }
-      count
-      page
-      perPage
-      activeFilters
+      pagination {
+        count
+        page
+        perPage
+      }
+      activeFilters {
+        postTypes
+        authors
+        from
+        to
+      }
     }
   }
 `

--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -8,41 +8,47 @@ import Skeleton from '../Skeleton/Skeleton'
 
 export const QUERY = gql`
   query ArticlesQuery($input: QueryPostsInput) {
-    articles: posts(input: $input) {
-      id
-      title
-      body
-      createdAt
-      videoPost {
-        videoUrl
-      }
-      user {
-        name
-        profile {
-          name
-          avatar
+    result: posts(input: $input) {
+      posts {
+        id
+        title
+        body
+        createdAt
+        videoPost {
+          videoUrl
         }
-      }
-      type
-      coverImage {
-        url
-      }
-      comments {
-        id
-      }
-      location
-      imageGalleries {
-        id
-        imageGallery {
+        user {
           name
-          description
-          images {
-            id
-            url
-            imageId
+          profile {
+            name
+            avatar
+          }
+        }
+        type
+        coverImage {
+          url
+        }
+        comments {
+          id
+        }
+        location
+        imageGalleries {
+          id
+          imageGallery {
+            name
+            description
+            images {
+              id
+              url
+              imageId
+            }
           }
         }
       }
+      count
+      page
+      perPage
+      activeFilters
     }
   }
 `
@@ -50,7 +56,7 @@ export const QUERY = gql`
 interface Props {
   vlog?: boolean
   gallery?: boolean
-  articles: CellSuccessProps<ArticlesQuery>
+  result: CellSuccessProps<ArticlesQuery>
 }
 
 export const Loading = () => (
@@ -69,14 +75,14 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ articles, vlog, gallery }: Props) => {
-  const vlogs = articles.filter((article) => {
+export const Success = ({ result, vlog, gallery }: Props) => {
+  const vlogs = result.posts.filter((article) => {
     if (article.type === EPostType.VIDEO) {
       return article
     }
   })
 
-  const galleries = articles.filter((article) => {
+  const galleries = result.posts.filter((article) => {
     if (article.type === EPostType.PHOTO_GALLERY) {
       return article
     }
@@ -104,7 +110,7 @@ export const Success = ({ articles, vlog, gallery }: Props) => {
 
   return (
     <ul className="flex flex-col justify-center gap-6 p-3 md:gap-12 md:p-10">
-      {articles.map((article) => {
+      {result.posts.map((article) => {
         return <ArticlePreview key={article.id} article={article} />
       })}
     </ul>

--- a/web/src/components/Pagination/Pagination.stories.tsx
+++ b/web/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,25 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```jsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import Pagination from './Pagination'
+
+const meta: Meta<typeof Pagination> = {
+  component: Pagination,
+}
+
+export default meta
+
+type Story = StoryObj<typeof Pagination>
+
+export const Primary: Story = {}

--- a/web/src/components/Pagination/Pagination.test.tsx
+++ b/web/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import Pagination from './Pagination'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('Pagination', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<Pagination />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Pagination/Pagination.test.tsx
+++ b/web/src/components/Pagination/Pagination.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@redwoodjs/testing/web'
+import { render, screen } from '@redwoodjs/testing/web'
 
 import Pagination from './Pagination'
 
@@ -7,8 +7,29 @@ import Pagination from './Pagination'
 
 describe('Pagination', () => {
   it('renders successfully', () => {
+    const pagination = {
+      count: 1,
+      page: 1,
+      perPage: 1,
+    }
+
     expect(() => {
-      render(<Pagination />)
+      render(<Pagination pagination={pagination} />)
     }).not.toThrow()
+  })
+
+  it('links to the correct page based on the routeName prop', () => {
+    const pagination = {
+      count: 100,
+      page: 3,
+      perPage: 10,
+    }
+
+    expect(() => {
+      render(<Pagination pagination={pagination} routeName="vlog" />)
+    }).not.toThrow()
+
+    const link = screen.getByRole('link', { name: '1' })
+    expect(link).toHaveAttribute('href', '/vlog?page=1')
   })
 })

--- a/web/src/components/Pagination/Pagination.tsx
+++ b/web/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,50 @@
+import { NavLink, routes } from '@redwoodjs/router'
+
+interface PaginationProps {
+  // type is the name of the object returned from a key from AvailableRoutes
+  routeName?: string
+  pagination: Pagination
+}
+
+const Pagination = ({ pagination, routeName = 'home' }: PaginationProps) => {
+  const { count, perPage } = pagination
+
+  const pages = Math.ceil(count / perPage)
+
+  const pageNumbers = []
+
+  for (let i = 1; i <= pages; i++) {
+    pageNumbers.push(i)
+  }
+
+  const pageNumbersJSX = pageNumbers.map((number) => {
+    const isCurrentPage = pagination.page === number
+
+    return (
+      <li key={number}>
+        {isCurrentPage ? (
+          <span className="inline-flex h-12 w-12 select-none justify-center rounded-full border-2 border-cobalt-blue-500 bg-cobalt-blue-500 px-3 py-2 text-center text-white">
+            {number}
+          </span>
+        ) : (
+          <NavLink
+            className="inline-flex h-12 w-12 justify-center rounded-full border-2 border-cobalt-blue-500 bg-white px-3 py-2 text-center text-cobalt-blue-500 hover:bg-cobalt-blue-500 hover:text-white"
+            activeClassName="!bg-cobalt-blue-500 text-white"
+            aria-current={isCurrentPage ? 'page' : undefined}
+            to={routes[routeName]({ page: number })}
+          >
+            {number}
+          </NavLink>
+        )}
+      </li>
+    )
+  })
+
+  return (
+    <div className="flex justify-center">
+      <ul className="flex space-x-2">{pageNumbersJSX}</ul>
+    </div>
+  )
+}
+
+export default Pagination

--- a/web/src/pages/GalleriesPage/GalleriesPage.tsx
+++ b/web/src/pages/GalleriesPage/GalleriesPage.tsx
@@ -1,12 +1,26 @@
+import { useParams } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
 import ArticlesCell from 'src/components/ArticlesCell'
 
 const GalleriesPage = () => {
+  const params = useParams()
+
+  const queryInput = {
+    page: params.page ? parseInt(params.page) : 1,
+    perPage: params.perPage ? parseInt(params.perPage) : 10,
+    postTypes: ['PHOTO_GALLERY'],
+    authors: params.authors
+      ? params.authors.split(',').map((a) => parseInt(a))
+      : [],
+    from: params.from ? new Date(params.from) : null,
+    to: params.to ? new Date(params.to) : null,
+  }
+
   return (
     <>
       <MetaTags title="Galleries" description="Galleries page" />
-      <ArticlesCell gallery />
+      <ArticlesCell gallery input={queryInput} />
     </>
   )
 }

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -1,12 +1,22 @@
+import { useParams } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
 import ArticlesCell from 'src/components/ArticlesCell'
 
 const HomePage = () => {
+  const params = useParams()
+
+  const queryInput = {
+    page: params.page ? parseInt(params.page) : 1,
+    perPage: params.perPage ? parseInt(params.perPage) : 10,
+    postTypes: params.postTypes ? params.postTypes : [],
+    authors: params.authors ? params.authors : [],
+  }
+
   return (
     <>
       <MetaTags title="Home" description="Home page" />
-      <ArticlesCell />
+      <ArticlesCell input={queryInput} />
     </>
   )
 }

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -9,8 +9,10 @@ const HomePage = () => {
   const queryInput = {
     page: params.page ? parseInt(params.page) : 1,
     perPage: params.perPage ? parseInt(params.perPage) : 10,
-    postTypes: params.postTypes ? params.postTypes : [],
-    authors: params.authors ? params.authors : [],
+    postTypes: params.postTypes ? params.postTypes.split(',') : [],
+    authors: params.authors
+      ? params.authors.split(',').map((a) => parseInt(a))
+      : [],
   }
 
   return (

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -13,6 +13,8 @@ const HomePage = () => {
     authors: params.authors
       ? params.authors.split(',').map((a) => parseInt(a))
       : [],
+    from: params.from ? new Date(params.from) : null,
+    to: params.to ? new Date(params.to) : null,
   }
 
   return (

--- a/web/src/pages/VlogPage/VlogPage.tsx
+++ b/web/src/pages/VlogPage/VlogPage.tsx
@@ -1,12 +1,26 @@
+import { useParams } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
 import ArticlesCell from 'src/components/ArticlesCell'
 
 const VlogPage = () => {
+  const params = useParams()
+
+  const queryInput = {
+    page: params.page ? parseInt(params.page) : 1,
+    perPage: params.perPage ? parseInt(params.perPage) : 10,
+    postTypes: ['VIDEO'],
+    authors: params.authors
+      ? params.authors.split(',').map((a) => parseInt(a))
+      : [],
+    from: params.from ? new Date(params.from) : null,
+    to: params.to ? new Date(params.to) : null,
+  }
+
   return (
     <>
       <MetaTags title="Vlog" description="Vlog page" />
-      <ArticlesCell vlog />
+      <ArticlesCell vlog input={queryInput} />
     </>
   )
 }


### PR DESCRIPTION
This PR adds the possibility to filter posts on the home page on the following properties:

- from (date)
- to (date)
- authors (list of user ids)
- post types (list of post type enum values)

Additionally you can paginate the posts by specifying the:
- page (page number)
- perPage (amount of posts per page)

Combining these features into a url would look like this example:

https://ohayo-goededagu.nl?page=1&perPage=10&from=2023-09-01&to=2023-09-31&authors=1,2,3&postTypes=PHOTO_GALLERY,CHOTTO,HAIKU

Note: if the build succeeds and netlify creates a deploy preview, this url should actually work 🤓 

Next step would then be to add a nice filter menu on the home page.