### PR TITLE
hide media library option for avatar picture if not an admin or mod

### DIFF
--- a/web/src/components/PostFilterMenu/PostFilterMenu.tsx
+++ b/web/src/components/PostFilterMenu/PostFilterMenu.tsx
@@ -19,7 +19,7 @@ const PostFilterMenu = ({
   const { postTypes = [], authors = [] } = activeFilters
 
   return (
-    <div className="flex flex-row flex-wrap gap-4">
+    <div className="flex flex-row flex-wrap justify-center gap-4">
       {showPostTypeFilter && <PostTypeFilter activePostTypes={postTypes} />}
       <UserFilterCell activeAuthors={authors} />
     </div>

--- a/web/src/components/Profile/ProfileForm/ProfileForm.tsx
+++ b/web/src/components/Profile/ProfileForm/ProfileForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@redwoodjs/forms'
 import type { RWGqlError } from '@redwoodjs/forms'
 
+import { useAuth } from 'src/auth'
 import Avatar from 'src/components/Avatar/Avatar'
 import MediaLibrary from 'src/components/MediaLibrary/MediaLibrary'
 import Upload, {
@@ -26,6 +27,8 @@ interface ProfileFormProps {
 }
 
 const ProfileForm = (props: ProfileFormProps) => {
+  const { isAuthenticated, hasRole } = useAuth()
+
   const onSubmit = (data: FormProfile) => {
     if (profilePicture) {
       if (data.avatar) {
@@ -125,10 +128,12 @@ const ProfileForm = (props: ProfileFormProps) => {
             handleUpload={handleUpload}
           />
 
-          <MediaLibrary
-            name="avatar"
-            handleMediaLibrary={handleMediaLibraryResponse}
-          />
+          {isAuthenticated && hasRole('MODERATOR' || 'ADMIN') && (
+            <MediaLibrary
+              name="avatar"
+              handleMediaLibrary={handleMediaLibraryResponse}
+            />
+          )}
 
           {profilePicture && (
             <Avatar src={profilePicture} alt="ProfilePicture" />


### PR DESCRIPTION
This PR hides the 'select from media library' button for uploading an avatar picture if you are not a moderator or admin