### PR TITLE
Fixed: Filter issues

### DIFF
--- a/web/src/components/ArticlesCell/ArticlesCell.tsx
+++ b/web/src/components/ArticlesCell/ArticlesCell.tsx
@@ -72,6 +72,24 @@ interface Props {
 
 export const Loading = () => (
   <div className="grid max-w-6xl">
+    <div className="flex flex-wrap justify-center gap-4 px-3">
+      <div className="flex gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton
+            key={i}
+            className="!h-12 !w-12 animate-pulse rounded-full bg-gray-200"
+          />
+        ))}
+      </div>
+      <div className="flex gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton
+            key={i}
+            className="!h-12 !w-12 animate-pulse rounded-full bg-gray-200"
+          />
+        ))}
+      </div>
+    </div>
     {Array.from({ length: 5 }).map((_, i) => (
       <div key={i}>
         <Skeleton className="m-3 h-80 rounded-md md:m-10 md:h-[480px]" />

--- a/web/src/components/Pagination/Pagination.tsx
+++ b/web/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { NavLink, routes } from '@redwoodjs/router'
+import { NavLink, routes, useParams } from '@redwoodjs/router'
 
 interface PaginationProps {
   // type is the name of the object returned from a key from AvailableRoutes
@@ -8,6 +8,7 @@ interface PaginationProps {
 
 const Pagination = ({ pagination, routeName = 'home' }: PaginationProps) => {
   const { count, perPage } = pagination
+  const currentParams = useParams()
 
   const pages = Math.ceil(count / perPage)
 
@@ -15,6 +16,13 @@ const Pagination = ({ pagination, routeName = 'home' }: PaginationProps) => {
 
   for (let i = 1; i <= pages; i++) {
     pageNumbers.push(i)
+  }
+
+  const getParams = (page: number) => {
+    return {
+      ...currentParams,
+      page,
+    }
   }
 
   const pageNumbersJSX = pageNumbers.map((number) => {
@@ -31,7 +39,7 @@ const Pagination = ({ pagination, routeName = 'home' }: PaginationProps) => {
             className="inline-flex h-12 w-12 justify-center rounded-full border-2 border-cobalt-blue-500 bg-white px-3 py-2 text-center text-cobalt-blue-500 hover:bg-cobalt-blue-500 hover:text-white"
             activeClassName="!bg-cobalt-blue-500 text-white"
             aria-current={isCurrentPage ? 'page' : undefined}
-            to={routes[routeName]({ page: number })}
+            to={routes[routeName](getParams(number))}
           >
             {number}
           </NavLink>

--- a/web/src/components/PostTypeFilter/PostTypeFilter.tsx
+++ b/web/src/components/PostTypeFilter/PostTypeFilter.tsx
@@ -26,21 +26,21 @@ const getParams = (
   postType: EPostType
 ) => {
   // if removing the last post type, remove the postTypes param
-  if (activePostTypes.length === 1 && activePostTypes.includes(postType)) {
-    const { postTypes: _postTypes, ...rest } = currentParams
+  const { postTypes: _postTypes, page: _page, ...rest } = currentParams
 
+  if (activePostTypes.length === 1 && activePostTypes.includes(postType)) {
     return rest
   }
 
   if (activePostTypes.includes(postType)) {
     return {
-      ...currentParams,
+      ...rest,
       postTypes: activePostTypes.filter((type) => type !== postType),
     }
   }
 
   return {
-    ...currentParams,
+    ...rest,
     postTypes: [...activePostTypes, postType],
   }
 }

--- a/web/src/components/UserFilter/UserFilter.tsx
+++ b/web/src/components/UserFilter/UserFilter.tsx
@@ -19,22 +19,22 @@ const getParams = (
   activeAuthors: number[],
   author: number
 ) => {
+  const { authors: _authors, page: _page, ...rest } = currentParams
+
   // if removing the last author, remove the authors param
   if (activeAuthors.length === 1 && activeAuthors.includes(author)) {
-    const { authors: _authors, ...rest } = currentParams
-
     return rest
   }
 
   if (activeAuthors.includes(author)) {
     return {
-      ...currentParams,
+      ...rest,
       authors: activeAuthors.filter((id) => id !== author),
     }
   }
 
   return {
-    ...currentParams,
+    ...rest,
     authors: [...activeAuthors, author],
   }
 }


### PR DESCRIPTION
This PR fixes the following:
- Page number in url not reset after changing the post type filter
- Page number in url not reset after changing the user filter
- Filter params incorrectly being reset after navigation to a different page in the navigation
- Jittering post filter menu skeleton

Resolves #222 