### PR TITLE
Mobile styling

### DIFF
--- a/web/src/components/Article/components/FullLayout/FullLayout.tsx
+++ b/web/src/components/Article/components/FullLayout/FullLayout.tsx
@@ -97,6 +97,12 @@ const FullLayout = ({ article }: Props) => {
       {!hasCoverImage && (
         <>
           <header className="mb-4 flex flex-col gap-1">
+            <div className="flex flex-row justify-end">
+              {isMobile && article.titleEn && article.bodyEn && (
+                <LanguageButton setEnglish={setEnglish} />
+              )}
+            </div>
+
             <div className="flex flex-row justify-between gap-2">
               <h1 className="flex items-center gap-2 text-3xl font-extrabold uppercase tracking-tight md:gap-4">
                 <ArticleTypeIcon type={article.type as EPostType} />
@@ -126,11 +132,13 @@ const FullLayout = ({ article }: Props) => {
                   className="pb-1 text-slate-500"
                 />
               </div>
-              {article.id && <PostThumbsCell postId={article.id} />}
+              <div className="flex flex-row gap-2 md:gap-6">
+                {!isMobile && article.titleEn && article.bodyEn && (
+                  <LanguageButton setEnglish={setEnglish} />
+                )}
+                {article.id && <PostThumbsCell postId={article.id} />}
+              </div>
             </div>
-            {article.titleEn && article.bodyEn && (
-              <LanguageButton setEnglish={setEnglish} />
-            )}
           </header>
         </>
       )}

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -41,29 +41,32 @@ const PreviewLayout = ({ article }: Props) => {
               className="prose mx-auto mb-8 line-clamp-3 max-h-[4.5rem] text-center text-[#d1d5db] md:max-h-[5.5rem] lg:max-h-24"
             />
           )}
-          <div className="flex flex-row items-center justify-center gap-12">
-            <AvatarTimestamp article={article} hasImage={hasImage} />
-            {article?.comments?.length > 0 && (
-              <ArticleCommentCountBadge count={article.comments.length} />
-            )}
-            {article.id && (
-              <PostThumbsCell postId={article.id} readOnly light />
-            )}
-
-            <Link
-              to={routes.article({ id: article.id })}
-              className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
-            >
-              <Button
-                text={
-                  article.type === EPostType.PHOTO_GALLERY
-                    ? "Zie alle foto's"
-                    : 'Lees verder'
-                }
-                icon={<BsArrowRightCircle />}
-                className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs"
-              />
-            </Link>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-row items-center justify-center gap-12">
+              <AvatarTimestamp article={article} hasImage={hasImage} />
+              <Link
+                to={routes.article({ id: article.id })}
+                className="items-center justify-end text-center text-base font-medium text-white focus:ring-4 focus:ring-gray-400"
+              >
+                <Button
+                  text={
+                    article.type === EPostType.PHOTO_GALLERY
+                      ? "Zie alle foto's"
+                      : 'Lees verder'
+                  }
+                  icon={<BsArrowRightCircle />}
+                  className="flex max-w-fit items-center justify-end gap-2 px-4 py-3 text-xs"
+                />
+              </Link>
+            </div>
+            <div className="flex flex-row flex-wrap items-center justify-center gap-2">
+              {article?.comments?.length > 0 && (
+                <ArticleCommentCountBadge count={article.comments.length} />
+              )}
+              {article.id && (
+                <PostThumbsCell postId={article.id} readOnly light />
+              )}
+            </div>
           </div>
         </>
       )}
@@ -99,7 +102,7 @@ const PreviewLayout = ({ article }: Props) => {
 
             <div className="flex items-center justify-between pt-4">
               <AvatarTimestamp article={article} hasImage={hasImage} />
-              <div className="flex items-center gap-6">
+              <div className="flex items-center gap-2 md:gap-6">
                 {article?.comments?.length > 0 && (
                   <ArticleCommentCountBadge
                     count={article.comments.length}

--- a/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
+++ b/web/src/components/Article/components/PreviewLayout/PreviewLayout.tsx
@@ -76,7 +76,7 @@ const PreviewLayout = ({ article }: Props) => {
             <div className="mt-4 flex flex-row items-center gap-2 pl-1">
               <ArticleTypeIcon type={article.type as EPostType} />
               <h2
-                className="text-xl font-semibold text-slate-700 md:text-2xl"
+                className="w-fit text-xl font-semibold text-slate-700 md:text-2xl"
                 title={article.title}
               >
                 <Link to={routes.article({ id: article.id })}>

--- a/web/src/components/ArticleCommentCountBadge/ArticleCommentCountBadge.tsx
+++ b/web/src/components/ArticleCommentCountBadge/ArticleCommentCountBadge.tsx
@@ -13,7 +13,7 @@ const ArticleCommentCountBadge = ({
 }: IArticleCommentCountBadgeProps) => {
   return (
     <div className="relative flex flex-row items-center justify-center gap-1">
-      <BsChatLeft size="2rem" fill={variant === 'light' ? '#fff' : '#000'}>
+      <BsChatLeft size="1.5rem" fill={variant === 'light' ? '#fff' : '#000'}>
         {count}
       </BsChatLeft>
       <span

--- a/web/src/components/ArticleTypeIcon/ArticleTypeIcon.tsx
+++ b/web/src/components/ArticleTypeIcon/ArticleTypeIcon.tsx
@@ -56,11 +56,11 @@ const ArticleTypeIcon = ({ type, showTitle = true }: IArticleTypeIconProps) => {
       <img
         src="/images/avatar.png"
         alt={type}
-        className="bg-cobalt-red-500 absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-full object-cover shadow"
+        className="bg-cobalt-red-500 absolute left-0 top-0 flex h-full w-full items-center justify-center rounded-full object-cover shadow"
         width={10}
         height={10}
       />
-      <div className="absolute flex h-10 w-10 items-center justify-center rounded-full bg-black opacity-20 "></div>
+      <div className="absolute flex h-full w-full items-center justify-center rounded-full bg-black opacity-20 "></div>
 
       <div className="absolute text-white"> {getIcon(type)}</div>
     </div>

--- a/web/src/components/LanguageButton/LanguageButton.tsx
+++ b/web/src/components/LanguageButton/LanguageButton.tsx
@@ -32,7 +32,7 @@ const LanguageButton = ({ article, readOnly, setEnglish }: Props) => {
         </div>
       )}
       {!readOnly && (
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row">
           <Button
             variant="outlined"
             className="hover:bg-slate-200"

--- a/web/src/components/Post/EditPostCell/EditPostCell.tsx
+++ b/web/src/components/Post/EditPostCell/EditPostCell.tsx
@@ -13,6 +13,8 @@ export const QUERY = gql`
       id
       title
       body
+      titleEn
+      bodyEn
       type
       createdAt
       published
@@ -62,6 +64,8 @@ const UPDATE_POST_MUTATION = gql`
       id
       title
       body
+      titleEn
+      bodyEn
       createdAt
       published
       videoPost {

--- a/web/src/components/Post/PostForm/PostForm.tsx
+++ b/web/src/components/Post/PostForm/PostForm.tsx
@@ -283,7 +283,7 @@ const PostForm = (props: PostFormProps) => {
 
               <FieldError name="body" className="rw-field-error" />
 
-              {!english && (
+              {!english && !postTitleEn && (
                 <>
                   <span className="rw-label">Add English:</span>
                   <Button
@@ -298,49 +298,50 @@ const PostForm = (props: PostFormProps) => {
                 </>
               )}
 
-              {english && (
-                <>
-                  <Label
-                    name="titleEn"
-                    className="rw-label"
-                    errorClassName="rw-label rw-label-error"
-                  >
-                    English Title
-                  </Label>
+              {english ||
+                (postTitleEn && (
+                  <>
+                    <Label
+                      name="titleEn"
+                      className="rw-label"
+                      errorClassName="rw-label rw-label-error"
+                    >
+                      English Title
+                    </Label>
 
-                  <TextField
-                    name="titleEn"
-                    defaultValue={postTitleEn}
-                    className="rw-input"
-                    errorClassName="rw-input rw-input-error"
-                    onChange={(e) => {
-                      setPostTitleEn(e.target.value)
-                    }}
-                    validation={{ required: false }}
-                  />
+                    <TextField
+                      name="titleEn"
+                      defaultValue={postTitleEn}
+                      className="rw-input"
+                      errorClassName="rw-input rw-input-error"
+                      onChange={(e) => {
+                        setPostTitleEn(e.target.value)
+                      }}
+                      validation={{ required: false }}
+                    />
 
-                  <FieldError name="titleEn" className="rw-field-error" />
+                    <FieldError name="titleEn" className="rw-field-error" />
 
-                  <Label
-                    name="bodyEn"
-                    className="rw-label"
-                    errorClassName="rw-label rw-label-error"
-                  >
-                    English Body
-                  </Label>
+                    <Label
+                      name="bodyEn"
+                      className="rw-label"
+                      errorClassName="rw-label rw-label-error"
+                    >
+                      English Body
+                    </Label>
 
-                  <MarkdownEditor
-                    name="bodyEn"
-                    value={postBodyEn}
-                    onChange={setPostBodyEn}
-                    validation={{
-                      required: !bodyEnNotRequired,
-                    }}
-                  />
+                    <MarkdownEditor
+                      name="bodyEn"
+                      value={postBodyEn}
+                      onChange={setPostBodyEn}
+                      validation={{
+                        required: !bodyEnNotRequired,
+                      }}
+                    />
 
-                  <FieldError name="bodyEn" className="rw-field-error" />
-                </>
-              )}
+                    <FieldError name="bodyEn" className="rw-field-error" />
+                  </>
+                ))}
 
               <Label
                 name="location"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -79,10 +79,10 @@
 
 /* blog */
 .blog-layout .google_translate  {
-  @apply fixed mt-16 pt-2 right-2 bottom-auto top-0 z-30 w-40 drop-shadow;
+  @apply fixed mt-16 pt-1 right-0 bottom-auto top-0 z-30 w-36 mr-2 md:w-40 md:mr-0 drop-shadow;
 
   .goog-te-combo {
-    @apply w-full;
+    @apply w-[9rem];
   }
 }
 


### PR DESCRIPTION
Some small fixes for mobile styling & english version

- Blogroll was overflowing on mobile because of too much info in one line. Fixed it by moving the comments & thumbs below the name, date & readmore button
- On mobile the line with name, date, location, languages and likes become too busy and squished. Fixed it by moving the language buttons on mobile
- On mobile the google translate button was pretty big, made it a little bit smaller
- On editing a post you did not see your english title&body if it was already there. Now it is 