### PR TITLE
Added: Optimize images

### DIFF
--- a/scripts/helpers/generate-many-posts.ts
+++ b/scripts/helpers/generate-many-posts.ts
@@ -1,6 +1,6 @@
 import getImageGalleriesCreateCommand from './create-image-galleries-command'
 
-function generateManyPosts(amount: number) {
+function generateManyPosts(amount: number, override?: Partial<Post>) {
   const posts = []
 
   for (let i = 0; i < amount; i++) {
@@ -22,6 +22,7 @@ function generateManyPosts(amount: number) {
       userId: 1,
       location: '1 Chome-1-2 Oshiage, Sumida City, Tokyo 131-0045, Japan',
       type: postType,
+      ...override,
     }
 
     if (postType === 'PHOTO_GALLERY') {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -202,6 +202,18 @@ export default async () => {
         type: 'PHOTO_GALLERY',
       },
       ...generateManyPosts(25),
+      {
+        title: 'Knalvis deluxe',
+        body: 'This is a post with a compressed cover image',
+        published: true,
+        userId: 1,
+        createdAt: new Date('2023-01-01'),
+        type: 'ARTICLE',
+        coverImage: {
+          imageId: 128381209,
+          url: 'https://images.pexels.com/photos/2892012/pexels-photo-2892012.jpeg',
+        },
+      },
     ]
 
     for (const post of posts) {

--- a/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
+++ b/web/src/components/Article/components/ArticleArticle/ArticleArticle.tsx
@@ -1,6 +1,7 @@
 import type { Post } from 'types/graphql'
 
 import LanguageButton from 'src/components/LanguageButton/LanguageButton'
+import { getCompressedImageUrl } from 'src/lib/get-compressed-image-url'
 import { EPostDisplayType } from 'src/types/post-display-type.enum'
 
 import FullLayout from '../FullLayout/FullLayout'
@@ -14,13 +15,18 @@ interface Props {
 const ArticleArticle = ({ article, displayType }: Props) => {
   const { coverImage } = article
 
+  const compressedCoverImage = coverImage?.url && {
+    ...coverImage,
+    url: getCompressedImageUrl(coverImage.url),
+  }
+
   return (
     <>
       {displayType === EPostDisplayType.PREVIEW && (
         <section
           style={{
             backgroundImage: coverImage?.url
-              ? `url(${coverImage.url})`
+              ? `url(${compressedCoverImage?.url})`
               : `url(/images/logo-full.png)`,
           }}
           className="rounded bg-gray-600 bg-cover bg-center bg-no-repeat bg-blend-multiply"

--- a/web/src/components/PhotoGrid/PhotoGrid.tsx
+++ b/web/src/components/PhotoGrid/PhotoGrid.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { ImageGalleryImage } from 'types/graphql'
 
 import { classNames } from 'src/lib/class-names'
+import { getCompressedImageUrl } from 'src/lib/get-compressed-image-url'
 
 import ImageModal from '../ImageModal/ImageModal'
 
@@ -21,7 +22,10 @@ export interface IModalInfo {
 }
 
 const PhotoGrid = ({ className, images = [], preview }: IPhotoGridProps) => {
-  const previewGallery = images?.slice(0, 4)
+  const previewGallery = images?.slice(0, 4).map((image) => ({
+    ...image,
+    url: getCompressedImageUrl(image.url),
+  }))
 
   const [modalInfo, setModalInfo] = React.useState<IModalInfo>()
 

--- a/web/src/lib/get-compressed-image-url.ts
+++ b/web/src/lib/get-compressed-image-url.ts
@@ -11,5 +11,9 @@ export const getCompressedImageUrl = (
 ) => {
   const [baseUrl, imageId] = url.split('upload/')
 
+  if (!imageId) {
+    return url
+  }
+
   return `${baseUrl}upload/q_auto:${options.qAuto}/c_scale,w_${options.width}/${imageId}`
 }

--- a/web/src/lib/get-compressed-image-url.ts
+++ b/web/src/lib/get-compressed-image-url.ts
@@ -1,0 +1,15 @@
+interface CloudinaryImageTransformOptions {
+  qAuto: 'low' | 'good' | 'eco'
+  width: number
+}
+
+// compressed url is done by splitting the url at upload/ and adding /upload/q_auto:low/c_scale,w_1024/ in between
+// see also: https://cloudinary.com/documentation/image_transformations#automatic_format_selection
+export const getCompressedImageUrl = (
+  url: string,
+  options: CloudinaryImageTransformOptions = { qAuto: 'eco', width: 1024 }
+) => {
+  const [baseUrl, imageId] = url.split('upload/')
+
+  return `${baseUrl}upload/q_auto:${options.qAuto}/c_scale,w_${options.width}/${imageId}`
+}


### PR DESCRIPTION
This PR adds compression & resizing to cloudinary's image urls if we look at cover images or photo galleries in preview mode to save bandwidth